### PR TITLE
Add AUST-type PV-upwind formulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple sandbox for unstructured-mesh spherical shallow water equation solvers.
 
 To run the shallow-water solver:
 
-    python3 swe.py 
+    python3 swe.py
     --mpas-file="path+name-to-mpas-mesh+init-file"
     --num-steps=number-of-time-steps
     --time-step=delta_t
@@ -31,23 +31,24 @@ Various Williamson et al SWE config.:
     --mesh-file="path+name-to-mpas-mesh-file"
     --init-file="path+name-to-mpas-init-file"
     --radius=6371220.
-    --test-case=2, 5
+    --test-case=N
 
 For example, to build + run the barotropic jet test case using the CVT-optimised 
 'level-7' icosahedral mesh:
 
-    python3 jet.py
-    --mesh-file="mesh_cvt_7ref.nc"
-    --init-file="jet_cvt_7ref.nc"
-    --with-pert=True
+    python3 jet.py \
+    --mesh-file="mesh_cvt_7.nc" \
+    --init-file="jet_cvt_7.nc" \
+    --with-pert=True \
     --radius=6371220.
 
-    python3 swe.py
-    --mpas-file="jet_cvt_7ref.nc"
-    --num-steps=4320
-    --time-step=120.
-    --save-freq=270
-    --operators="TRSK-CV"
+    python3 swe.py \
+    --mpas-file="jet_cvt_7.nc" \
+    --num-steps=2400 \
+    --time-step=216. \
+    --save-freq=400 \
+    --stat-freq=100 \
+    --integrate="RK32-FB"
 
-Output is saved to the `out_jet_cvt_7ref.nc` file, which can be opened for visualisation 
+Output is saved to the `out_jet_cvt_7.nc` file, which can be opened for visualisation 
 in paraview.

--- a/_dt.py
+++ b/_dt.py
@@ -1,0 +1,1143 @@
+
+import time
+import numpy as np
+
+#-- SWE time integration via various Runge-Kutta methods
+#--
+#-- Darren Engwirda
+
+from _dx import invariant, upwinding, tcpu, \
+                compute_H, computePV, \
+                computeKE, advect_PV, computeDU
+
+def step_RK22(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
+
+#-- A 2-stage RK2 + FB scheme, a'la ROMS:
+#-- A.F. Shchepetkin, J.C. McWilliams (2005): The regional oceanic 
+#-- modeling system (ROMS): a split-explicit, free-surface, 
+#-- topography-following-coordinate oceanic model
+#-- doi.org/10.1016/j.ocemod.2004.08.002
+
+#-- but with thickness updated via an SSP-RK2 approach
+
+    ff_cell = flow.ff_cell
+    ff_edge = flow.ff_edge
+    ff_dual = flow.ff_vert
+
+    zb_cell = flow.zb_cell
+
+#-- 1st RK + FB stage
+
+    ttic = time.time()
+
+    BETA = (1.0 / 3.0) * ("FB" in cnfg.integrate)
+
+    vv_edge = trsk.edge_lsqr_perp * uu_edge
+
+    hh_dual, \
+    hh_edge = compute_H(mesh, trsk, cnfg, hh_cell, uu_edge)
+
+    uh_edge = uu_edge * hh_edge
+
+    uh_cell = trsk.cell_flux_sums * uh_edge
+    uh_cell/= mesh.cell.area
+
+    h1_cell = (
+        hh_cell - 1.0 / 1.0 * cnfg.time_step * uh_cell
+    )
+
+    ttoc = time.time()
+    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
+
+    ttic = time.time()
+
+    hb_cell = h1_cell * (0.0 + 1.0 * BETA) + \
+              hh_cell * (1.0 - 1.0 * BETA)
+
+    hb_dual, \
+    hb_edge = compute_H(mesh, trsk, cnfg, hb_cell, uu_edge)
+
+    uh_edge = uu_edge * hb_edge
+
+    ke_dual, ke_cell, __ = computeKE(
+        mesh, trsk, cnfg, 
+        hb_cell, hb_edge, hb_dual, 
+        uu_edge, vv_edge,
+        +1.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
+
+    hk_cell = hb_cell + zb_cell 
+    hk_cell = ke_cell + hk_cell * flow.grav
+
+    hk_grad = trsk.edge_grad_norm * hk_cell
+
+    rv_dual, pv_dual, rv_cell, pv_cell, \
+    pv_edge, __ = computePV(
+        mesh, trsk, cnfg, 
+        hb_cell, hb_edge, hb_dual, uu_edge, vv_edge, 
+        ff_dual, ff_edge, ff_cell, 
+        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
+
+    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
+
+    uu_damp = computeDU(mesh, trsk, cnfg, uu_edge)
+
+    u1_edge = uu_edge - 1.0 / 1.0 * cnfg.time_step * (
+        hk_grad + qh_flux - uu_damp
+    )
+
+    ttoc = time.time()
+    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
+
+#-- 2nd RK + FB stage
+
+    ttic = time.time()
+
+    BETA = (2.0 / 3.0) * ("FB" in cnfg.integrate)
+
+    hm_cell = 0.5 * hh_cell + 0.5 * h1_cell
+    um_edge = 0.5 * uu_edge + 0.5 * u1_edge
+
+    vm_edge = trsk.edge_lsqr_perp * um_edge
+
+    h1_dual, \
+    h1_edge = compute_H(mesh, trsk, cnfg, h1_cell, u1_edge)
+
+    uh_edge = u1_edge * h1_edge
+
+    uh_cell = trsk.cell_flux_sums * uh_edge
+    uh_cell/= mesh.cell.area
+
+    h2_cell = (
+        hm_cell - 1.0 / 2.0 * cnfg.time_step * uh_cell
+    )
+
+    ttoc = time.time()
+    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
+
+    ttic = time.time()
+
+    hb_cell = h2_cell * (0.0 + 0.5 * BETA) + \
+              h1_cell * (0.5 - 0.5 * BETA) + \
+              hh_cell * (0.5)
+
+    hb_dual, \
+    hb_edge = compute_H(mesh, trsk, cnfg, hb_cell, um_edge)
+
+    uh_edge = um_edge * hb_edge
+
+    ke_dual, ke_cell, ke_bias = computeKE(
+        mesh, trsk, cnfg, 
+        hb_cell, hb_edge, hb_dual, 
+        um_edge, vm_edge,
+        +1.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
+
+    hk_cell = hb_cell + zb_cell 
+    hk_cell = ke_cell + hk_cell * flow.grav
+
+    hk_grad = trsk.edge_grad_norm * hk_cell
+
+    rv_dual, pv_dual, rv_cell, pv_cell, \
+    pv_edge, pv_bias = computePV(
+        mesh, trsk, cnfg, 
+        hb_cell, hb_edge, hb_dual, um_edge, vm_edge,
+        ff_dual, ff_edge, ff_cell, 
+        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
+
+    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
+
+    uu_damp = computeDU(mesh, trsk, cnfg, um_edge)
+
+    u2_edge = uu_edge - 1.0 / 1.0 * cnfg.time_step * (
+        hk_grad + qh_flux - uu_damp
+    )
+
+    ttoc = time.time()
+    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
+
+    return h2_cell, u2_edge, ke_cell, ke_dual, \
+           rv_cell, pv_cell, \
+           rv_dual, pv_dual, ke_bias, pv_bias
+
+
+def step_BT22(mesh, trsk, flow, cnfg, hh_cell, uu_edge, 
+                                      ru_edge) :
+
+#-- A 2-stage RK2 + FB scheme, a'la ROMS:
+#-- A.F. Shchepetkin, J.C. McWilliams (2005): The regional oceanic 
+#-- modeling system (ROMS): a split-explicit, free-surface, 
+#-- topography-following-coordinate oceanic model
+#-- doi.org/10.1016/j.ocemod.2004.08.002
+
+#-- but with thickness updated via an SSP-RK2 approach
+
+    ff_cell = flow.ff_cell
+    ff_edge = flow.ff_edge
+    ff_dual = flow.ff_vert
+
+    zb_cell = flow.zb_cell
+
+#-- 1st RK + FB stage
+
+    ttic = time.time()
+
+    BETA = (1.0 / 3.0) * ("FB" in cnfg.integrate)
+
+    vv_edge = trsk.edge_lsqr_perp * uu_edge
+
+    hh_dual, \
+    hh_edge = compute_H(mesh, trsk, cnfg, hh_cell, uu_edge)
+
+    uh_edge = uu_edge * hh_edge
+
+    uh_cell = trsk.cell_flux_sums * uh_edge
+    uh_cell/= mesh.cell.area
+
+    h1_cell = (
+        hh_cell - 1.0 / 1.0 * cnfg._btr_step * uh_cell
+    )
+
+    ttoc = time.time()
+    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
+
+    ttic = time.time()
+
+    hb_cell = h1_cell * (0.0 + 1.0 * BETA) + \
+              hh_cell * (1.0 - 1.0 * BETA)
+
+    hz_cell = hb_cell + zb_cell
+    hz_cell*= flow.grav
+
+    hz_grad = trsk.edge_grad_norm * hz_cell
+
+    u1_edge = uu_edge - 1.0 / 1.0 * cnfg._btr_step * (
+        hz_grad - ru_edge
+    )
+
+    ttoc = time.time()
+    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
+
+#-- 2nd RK + FB stage
+
+    ttic = time.time()
+
+    BETA = (2.0 / 3.0) * ("FB" in cnfg.integrate)
+
+    hm_cell = 0.5 * hh_cell + 0.5 * h1_cell
+    um_edge = 0.5 * uu_edge + 0.5 * u1_edge
+
+    h1_dual, \
+    h1_edge = compute_H(mesh, trsk, cnfg, h1_cell, u1_edge)
+
+    uh_edge = u1_edge * h1_edge
+
+    uh_cell = trsk.cell_flux_sums * uh_edge
+    uh_cell/= mesh.cell.area
+
+    h2_cell = (
+        hm_cell - 1.0 / 2.0 * cnfg._btr_step * uh_cell
+    )
+
+    ttoc = time.time()
+    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
+
+    ttic = time.time()
+
+    hb_cell = h2_cell * (0.0 + 0.5 * BETA) + \
+              h1_cell * (0.5 - 0.5 * BETA) + \
+              hh_cell * (0.5)
+
+    hz_cell = hb_cell + zb_cell
+    hz_cell*= flow.grav
+
+    hz_grad = trsk.edge_grad_norm * hz_cell
+
+    u2_edge = uu_edge - 1.0 / 1.0 * cnfg._btr_step * (
+        hz_grad - ru_edge
+    )
+
+    ttoc = time.time()
+    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
+
+    return h2_cell, u2_edge, hz_grad
+
+
+def step_SE22(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
+
+#-- A split version of the RK22-FB scheme, with the surface waves
+#-- evaluated within each parent RK22-FB stage, using the RK22-FB
+#-- scheme on a sub-timestep. 
+
+    ff_cell = flow.ff_cell
+    ff_edge = flow.ff_edge
+    ff_dual = flow.ff_vert
+
+    zb_cell = flow.zb_cell
+
+    cnfg._btr_subs = 3
+    cnfg._btr_step = cnfg.time_step / cnfg._btr_subs
+
+#-- 1st-stage: (n+0/1)
+#-- assemble explicit momentum forcings - btr terms
+
+    ttic = time.time()
+
+    vv_edge = trsk.edge_lsqr_perp * uu_edge
+
+    hh_dual, \
+    hh_edge = compute_H(mesh, trsk, cnfg, hh_cell, uu_edge)
+
+    uh_edge = uu_edge * hh_edge
+
+    ke_dual, ke_cell, ke_bias = computeKE(
+        mesh, trsk, cnfg, 
+        hh_cell, hh_edge, hh_dual, 
+        uu_edge, vv_edge,
+        +1.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
+
+    ke_grad = trsk.edge_grad_norm * ke_cell
+
+    rv_dual, pv_dual, rv_cell, pv_cell, \
+    pv_edge, pv_bias = computePV(
+        mesh, trsk, cnfg, 
+        hh_cell, hh_edge, hh_dual, uu_edge, vv_edge, 
+        ff_dual, ff_edge, ff_cell, 
+        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
+
+    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
+
+    uu_damp = computeDU(mesh, trsk, cnfg, uu_edge)
+
+    ttoc = time.time()
+    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
+
+#-- run btr loop; advance to h1 and mean(btr) terms
+
+    ru_edge = uu_damp - qh_flux - ke_grad
+    
+    bu_edge = uu_edge[:]
+    bh_cell = hh_cell[:]
+    bt_grad = ke_grad[:] * 0.0
+    
+    for isub in range(cnfg._btr_subs):
+
+        bh_cell, bu_edge, \
+        hz_grad = step_BT22(
+            mesh, trsk,
+            flow, cnfg, bh_cell, bu_edge, ru_edge)
+
+        bt_grad+= hz_grad / cnfg._btr_subs
+
+    hk_grad = ke_grad + bt_grad
+
+#-- correct onto long time-step; advance to (h1,u1)
+
+    h1_cell = bh_cell
+    u1_edge = uu_edge - 1.0 / 1.0 * cnfg.time_step * (
+        hk_grad + qh_flux - uu_damp
+    )
+
+#-- 2nd-stage: (n+1/2)
+#-- assemble explicit momentum forcings - btr terms
+
+    ttic = time.time()
+
+    rk_bias = 1./300.  # tiny offcentre
+
+    hm_cell = (0.5 - rk_bias) * hh_cell + \
+              (0.5 + rk_bias) * h1_cell
+    um_edge = (0.5 - rk_bias) * uu_edge + \
+              (0.5 + rk_bias) * u1_edge
+
+    vm_edge = trsk.edge_lsqr_perp * um_edge
+
+    hm_dual, \
+    hm_edge = compute_H(mesh, trsk, cnfg, hm_cell, um_edge)
+
+    uh_edge = um_edge * hm_edge
+
+    ke_dual, ke_cell, ke_bias = computeKE(
+        mesh, trsk, cnfg, 
+        hm_cell, hm_edge, hm_dual, 
+        um_edge, vm_edge,
+        +1.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
+
+    ke_grad = trsk.edge_grad_norm * ke_cell
+
+    rv_dual, pv_dual, rv_cell, pv_cell, \
+    pv_edge, pv_bias = computePV(
+        mesh, trsk, cnfg, 
+        hm_cell, hm_edge, hm_dual, um_edge, vm_edge, 
+        ff_dual, ff_edge, ff_cell, 
+        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
+
+    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
+
+    uu_damp = computeDU(mesh, trsk, cnfg, um_edge)
+
+    ttoc = time.time()
+    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
+
+#-- run btr loop; advance to h2 and mean(btr) terms
+
+    ru_edge = uu_damp - qh_flux - ke_grad
+    
+    bu_edge = uu_edge[:]
+    bh_cell = hh_cell[:]
+    bt_grad = ke_grad[:] * 0.0
+
+    for isub in range(cnfg._btr_subs):
+
+        bh_cell, bu_edge, \
+        hz_grad = step_BT22(
+            mesh, trsk,
+            flow, cnfg, bh_cell, bu_edge, ru_edge)
+
+        bt_grad+= hz_grad / cnfg._btr_subs
+
+    hk_grad = ke_grad + bt_grad
+
+#-- correct onto long time-step; advance to (h2,u2)
+
+    h2_cell = bh_cell
+
+    u2_edge = uu_edge - 1.0 / 1.0 * cnfg.time_step * (
+        hk_grad + qh_flux - uu_damp
+    )
+
+    return h2_cell, u2_edge, ke_cell, ke_dual, \
+           rv_cell, pv_cell, \
+           rv_dual, pv_dual, ke_bias, pv_bias
+
+
+def step_RK32(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
+
+#-- A 3-stage RK2 + FB scheme, a'la MPAS-A:
+#-- L.J. Wicker, W.C. Skamarock (2002): Time-Splitting Methods for 
+#-- Elastic Models Using Forward Time Schemes
+#-- doi.org/10.1175/1520-0493(2002)130<2088:TSMFEM>2.0.CO;2
+
+#-- but with FB weighting applied within each RK stage
+
+    ff_cell = flow.ff_cell
+    ff_edge = flow.ff_edge
+    ff_dual = flow.ff_vert
+
+    zb_cell = flow.zb_cell
+
+#-- 1st RK + FB stage
+
+    ttic = time.time()
+
+    BETA = (1.0 / 3.0) * ("FB" in cnfg.integrate)
+
+    vv_edge = trsk.edge_lsqr_perp * uu_edge
+
+    hh_dual, \
+    hh_edge = compute_H(mesh, trsk, cnfg, hh_cell, uu_edge)
+
+    uh_edge = uu_edge * hh_edge
+
+    uh_cell = trsk.cell_flux_sums * uh_edge
+    uh_cell/= mesh.cell.area
+
+    h1_cell = (
+        hh_cell - 1.0 / 3.0 * cnfg.time_step * uh_cell
+    )
+
+    ttoc = time.time()
+    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
+
+    ttic = time.time()
+
+    hb_cell = h1_cell * (0.0 + 1.0 * BETA) + \
+              hh_cell * (1.0 - 1.0 * BETA)
+
+    hb_dual, \
+    hb_edge = compute_H(mesh, trsk, cnfg, hb_cell, uu_edge)
+
+    uh_edge = uu_edge * hb_edge
+
+    ke_dual, ke_cell, __ = computeKE(
+        mesh, trsk, cnfg, 
+        hb_cell, hb_edge, hb_dual, 
+        uu_edge, vv_edge,
+        +1.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
+
+    hk_cell = hb_cell + zb_cell 
+    hk_cell = ke_cell + hk_cell * flow.grav
+
+    hk_grad = trsk.edge_grad_norm * hk_cell
+
+    rv_dual, pv_dual, rv_cell, pv_cell, \
+    pv_edge, __ = computePV(
+        mesh, trsk, cnfg, 
+        hb_cell, hb_edge, hb_dual, uu_edge, vv_edge, 
+        ff_dual, ff_edge, ff_cell, 
+        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
+
+    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
+
+    uu_damp = computeDU(mesh, trsk, cnfg, uu_edge)
+
+    u1_edge = uu_edge - 1.0 / 3.0 * cnfg.time_step * (
+        hk_grad + qh_flux - uu_damp
+    )
+
+    ttoc = time.time()
+    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
+
+#-- 2nd RK + FB stage
+
+    ttic = time.time()
+
+    BETA = (1.0 / 2.0) * ("FB" in cnfg.integrate)
+
+    v1_edge = trsk.edge_lsqr_perp * u1_edge
+
+    h1_dual, \
+    h1_edge = compute_H(mesh, trsk, cnfg, h1_cell, u1_edge)
+
+    uh_edge = u1_edge * h1_edge
+
+    uh_cell = trsk.cell_flux_sums * uh_edge
+    uh_cell/= mesh.cell.area
+
+    h2_cell = (
+        hh_cell - 1.0 / 2.0 * cnfg.time_step * uh_cell
+    )
+
+    ttoc = time.time()
+    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
+
+    ttic = time.time()
+
+    # centred at 1/4 for 1/2 step?
+    hb_cell = h2_cell * (0.0 + 1.0 * BETA) + \
+              hh_cell * (1.0 - 1.0 * BETA)
+
+    hb_dual, \
+    hb_edge = compute_H(mesh, trsk, cnfg, hb_cell, u1_edge)
+
+    uh_edge = u1_edge * hb_edge
+
+    ke_dual, ke_cell, __ = computeKE(
+        mesh, trsk, cnfg, 
+        hb_cell, hb_edge, hb_dual, 
+        u1_edge, v1_edge,
+        +1.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
+
+    hk_cell = hb_cell + zb_cell 
+    hk_cell = ke_cell + hk_cell * flow.grav
+
+    hk_grad = trsk.edge_grad_norm * hk_cell
+
+    rv_dual, pv_dual, rv_cell, pv_cell, \
+    pv_edge, __ = computePV(
+        mesh, trsk, cnfg, 
+        hb_cell, hb_edge, hb_dual, u1_edge, v1_edge, 
+        ff_dual, ff_edge, ff_cell, 
+        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
+
+    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
+
+    uu_damp = computeDU(mesh, trsk, cnfg, u1_edge)
+
+    u2_edge = uu_edge - 1.0 / 2.0 * cnfg.time_step * (
+        hk_grad + qh_flux - uu_damp
+    )
+
+    ttoc = time.time()
+    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
+
+#-- 3rd RK + FB stage
+
+    ttic = time.time()
+
+    BETA = (89. / 300) * ("FB" in cnfg.integrate) 
+
+    v2_edge = trsk.edge_lsqr_perp * u2_edge
+
+    h2_dual, \
+    h2_edge = compute_H(mesh, trsk, cnfg, h2_cell, u2_edge)
+
+    uh_edge = u2_edge * h2_edge
+
+    uh_cell = trsk.cell_flux_sums * uh_edge
+    uh_cell/= mesh.cell.area
+
+    h3_cell = (
+        hh_cell - 1.0 / 1.0 * cnfg.time_step * uh_cell
+    )
+
+    ttoc = time.time()
+    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
+
+    ttic = time.time()
+
+    # centred at 1/2 for 1/1 step?
+    hb_cell = h3_cell * (0.0 + 1.0 * BETA) + \
+              h2_cell * (1.0 - 2.0 * BETA) + \
+              hh_cell * (0.0 + 1.0 * BETA)
+
+    hb_dual, \
+    hb_edge = compute_H(mesh, trsk, cnfg, hb_cell, u2_edge)
+
+    uh_edge = u2_edge * hb_edge
+
+    ke_dual, ke_cell, ke_bias = computeKE(
+        mesh, trsk, cnfg, 
+        hb_cell, hb_edge, hb_dual, 
+        u2_edge, v2_edge,
+        +1.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
+
+    hk_cell = hb_cell + zb_cell 
+    hk_cell = ke_cell + hk_cell * flow.grav
+
+    hk_grad = trsk.edge_grad_norm * hk_cell
+
+    rv_dual, pv_dual, rv_cell, pv_cell, \
+    pv_edge, pv_bias = computePV(
+        mesh, trsk, cnfg, 
+        hb_cell, hb_edge, hb_dual, u2_edge, v2_edge,
+        ff_dual, ff_edge, ff_cell, 
+        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
+
+    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
+
+    uu_damp = computeDU(mesh, trsk, cnfg, u2_edge)
+
+    u3_edge = uu_edge - 1.0 / 1.0 * cnfg.time_step * (
+        hk_grad + qh_flux - uu_damp
+    )
+
+    ttoc = time.time()
+    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
+
+    return h3_cell, u3_edge, ke_cell, ke_dual, \
+           rv_cell, pv_cell, \
+           rv_dual, pv_dual, ke_bias, pv_bias
+
+
+def step_BT32(mesh, trsk, flow, cnfg, hh_cell, uu_edge, 
+                                      ru_edge) :
+
+#-- A 3-stage RK2 + FB scheme, a'la MPAS-A:
+#-- L.J. Wicker, W.C. Skamarock (2002): Time-Splitting Methods for 
+#-- Elastic Models Using Forward Time Schemes
+#-- doi.org/10.1175/1520-0493(2002)130<2088:TSMFEM>2.0.CO;2
+
+#-- but with FB weighting applied within each RK stage
+
+    ff_cell = flow.ff_cell
+    ff_edge = flow.ff_edge
+    ff_dual = flow.ff_vert
+
+    zb_cell = flow.zb_cell
+
+#-- 1st RK + FB stage
+
+    ttic = time.time()
+
+    BETA = (1.0 / 3.0) * ("FB" in cnfg.integrate)
+
+    hh_dual, \
+    hh_edge = compute_H(mesh, trsk, cnfg, hh_cell, uu_edge)
+
+    uh_edge = uu_edge * hh_edge
+
+    uh_cell = trsk.cell_flux_sums * uh_edge
+    uh_cell/= mesh.cell.area
+
+    h1_cell = (
+        hh_cell - 1.0 / 3.0 * cnfg._btr_step * uh_cell
+    )
+
+    ttoc = time.time()
+    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
+
+    ttic = time.time()
+
+    hb_cell = h1_cell * (0.0 + 1.0 * BETA) + \
+              hh_cell * (1.0 - 1.0 * BETA)
+
+    hz_cell = hb_cell + zb_cell
+    hz_cell*= flow.grav
+
+    hz_grad = trsk.edge_grad_norm * hz_cell
+
+    u1_edge = uu_edge - 1.0 / 3.0 * cnfg._btr_step * (
+        hz_grad - ru_edge
+    )
+
+    ttoc = time.time()
+    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
+
+#-- 2nd RK + FB stage
+
+    ttic = time.time()
+
+    BETA = (1.0 / 2.0) * ("FB" in cnfg.integrate)
+
+    h1_dual, \
+    h1_edge = compute_H(mesh, trsk, cnfg, h1_cell, u1_edge)
+
+    uh_edge = u1_edge * h1_edge
+
+    uh_cell = trsk.cell_flux_sums * uh_edge
+    uh_cell/= mesh.cell.area
+
+    h2_cell = (
+        hh_cell - 1.0 / 2.0 * cnfg._btr_step * uh_cell
+    )
+
+    ttoc = time.time()
+    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
+
+    ttic = time.time()
+
+    # centred at 1/4 for 1/2 step?
+    hb_cell = h2_cell * (0.0 + 1.0 * BETA) + \
+              hh_cell * (1.0 - 1.0 * BETA)
+
+    hz_cell = hb_cell + zb_cell
+    hz_cell*= flow.grav
+
+    hz_grad = trsk.edge_grad_norm * hz_cell
+
+    u2_edge = uu_edge - 1.0 / 2.0 * cnfg._btr_step * (
+        hz_grad - ru_edge
+    )
+
+    ttoc = time.time()
+    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
+
+#-- 3rd RK + FB stage
+
+    ttic = time.time()
+
+    BETA = (89. / 300) * ("FB" in cnfg.integrate)
+    
+    h2_dual, \
+    h2_edge = compute_H(mesh, trsk, cnfg, h2_cell, u2_edge)
+
+    uh_edge = u2_edge * h2_edge
+
+    uh_cell = trsk.cell_flux_sums * uh_edge
+    uh_cell/= mesh.cell.area
+
+    h3_cell = (
+        hh_cell - 1.0 / 1.0 * cnfg._btr_step * uh_cell
+    )
+
+    ttoc = time.time()
+    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
+
+    ttic = time.time()
+
+    # centred at 1/2 for 1/1 step?
+    hb_cell = h3_cell * (0.0 + 1.0 * BETA) + \
+              h2_cell * (1.0 - 2.0 * BETA) + \
+              hh_cell * (0.0 + 1.0 * BETA)
+
+    hz_cell = hb_cell + zb_cell
+    hz_cell*= flow.grav
+
+    hz_grad = trsk.edge_grad_norm * hz_cell
+
+    u3_edge = uu_edge - 1.0 / 1.0 * cnfg._btr_step * (
+        hz_grad - ru_edge
+    )
+
+    ttoc = time.time()
+    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
+
+    return h3_cell, u3_edge, hz_grad
+
+
+def step_SE32(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
+
+#-- A split version of the RK32-FB scheme, with the surface waves
+#-- evaluated within each parent RK32-FB stage, using the RK32-FB
+#-- scheme on a sub-timestep.  
+
+    ff_cell = flow.ff_cell
+    ff_edge = flow.ff_edge
+    ff_dual = flow.ff_vert
+
+    zb_cell = flow.zb_cell
+
+    bt_grad = np.zeros(
+        (mesh.edge.size), dtype=np.float64)
+
+#-- 1st-stage: (n+0/1)
+#-- assemble explicit momentum forcings - btr terms
+
+    ttic = time.time()
+
+    vv_edge = trsk.edge_lsqr_perp * uu_edge
+
+    hh_dual, \
+    hh_edge = compute_H(mesh, trsk, cnfg, hh_cell, uu_edge)
+
+    uh_edge = uu_edge * hh_edge
+
+    ke_dual, ke_cell, ke_bias = computeKE(
+        mesh, trsk, cnfg, 
+        hh_cell, hh_edge, hh_dual, 
+        uu_edge, vv_edge,
+        +1.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
+
+    ke_grad = trsk.edge_grad_norm * ke_cell
+
+    rv_dual, pv_dual, rv_cell, pv_cell, \
+    pv_edge, pv_bias = computePV(
+        mesh, trsk, cnfg, 
+        hh_cell, hh_edge, hh_dual, uu_edge, vv_edge, 
+        ff_dual, ff_edge, ff_cell, 
+        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
+
+    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
+
+    uu_damp = computeDU(mesh, trsk, cnfg, uu_edge)
+
+    ttoc = time.time()
+    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
+
+#-- run btr loop; advance to h1 and mean(btr) terms
+
+    cnfg._btr_step = cnfg.time_step / 6.0
+
+    ru_edge = uu_damp - qh_flux - ke_grad
+
+    bh_cell, bu_edge, hz_grad = step_BT32(
+        mesh, trsk, flow, cnfg , hh_cell, uu_edge, ru_edge)
+
+    bt_grad+= hz_grad * 1.0 / 6.0
+
+    bh_cell, bu_edge, hz_grad = step_BT32(
+        mesh, trsk, flow, cnfg , bh_cell, bu_edge, ru_edge)
+
+    bt_grad+= hz_grad * 1.0 / 6.0
+
+#-- correct onto long time-step; advance to (h1,u1)
+
+    h1_cell = bh_cell
+    u1_edge = uu_edge - 1.0 / 3.0 * cnfg.time_step * (
+        3.0 * bt_grad + 
+            ke_grad + qh_flux - uu_damp
+    )
+
+#-- 2nd-stage: (n+1/3)
+#-- assemble explicit momentum forcings - btr terms
+
+    ttic = time.time()
+
+    v1_edge = trsk.edge_lsqr_perp * u1_edge
+
+    h1_dual, \
+    h1_edge = compute_H(mesh, trsk, cnfg, h1_cell, u1_edge)
+
+    uh_edge = u1_edge * h1_edge
+
+    ke_dual, ke_cell, ke_bias = computeKE(
+        mesh, trsk, cnfg, 
+        h1_cell, h1_edge, h1_dual, 
+        u1_edge, v1_edge,
+        +1.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
+
+    ke_grad = trsk.edge_grad_norm * ke_cell
+
+    rv_dual, pv_dual, rv_cell, pv_cell, \
+    pv_edge, pv_bias = computePV(
+        mesh, trsk, cnfg, 
+        h1_cell, h1_edge, h1_dual, u1_edge, v1_edge, 
+        ff_dual, ff_edge, ff_cell, 
+        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
+
+    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
+
+    uu_damp = computeDU(mesh, trsk, cnfg, u1_edge)
+
+    ttoc = time.time()
+    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
+
+#-- run btr loop; advance to h2 and mean(btr) terms
+
+    cnfg._btr_step = cnfg.time_step / 6.0
+
+    ru_edge = uu_damp - qh_flux - ke_grad
+    
+    bh_cell, bu_edge, hz_grad = step_BT32(
+        mesh, trsk, flow, cnfg , h1_cell, u1_edge, ru_edge)
+
+    bt_grad+= hz_grad * 1.0 / 6.0
+
+#-- correct onto long time-step; advance to (h2,u2)
+
+    h2_cell = bh_cell
+    u2_edge = uu_edge - 1.0 / 2.0 * cnfg.time_step * (
+        2.0 * bt_grad + 
+            ke_grad + qh_flux - uu_damp
+    )
+
+#-- 3rd-stage: (n+1/2)
+#-- assemble explicit momentum forcings - btr terms
+
+    ttic = time.time()
+
+    v2_edge = trsk.edge_lsqr_perp * u2_edge
+
+    h2_dual, \
+    h2_edge = compute_H(mesh, trsk, cnfg, h2_cell, u2_edge)
+
+    uh_edge = u2_edge * h2_edge
+
+    ke_dual, ke_cell, ke_bias = computeKE(
+        mesh, trsk, cnfg, 
+        h2_cell, h2_edge, h2_dual, 
+        u2_edge, v2_edge,
+        +1.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
+
+    ke_grad = trsk.edge_grad_norm * ke_cell
+
+    rv_dual, pv_dual, rv_cell, pv_cell, \
+    pv_edge, pv_bias = computePV(
+        mesh, trsk, cnfg, 
+        h2_cell, h2_edge, h2_dual, u2_edge, v2_edge, 
+        ff_dual, ff_edge, ff_cell, 
+        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
+
+    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
+
+    uu_damp = computeDU(mesh, trsk, cnfg, u2_edge)
+
+    ttoc = time.time()
+    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
+
+#-- run btr loop; advance to h3 and mean(btr) terms
+
+    cnfg._btr_step = cnfg.time_step / 5.0
+
+    ru_edge = uu_damp - qh_flux - ke_grad
+
+    bt_grad = bt_grad * 0.0 
+    
+    bh_cell, bu_edge, hz_grad = step_BT32(
+        mesh, trsk, flow, cnfg , hh_cell, uu_edge, ru_edge)
+
+    bt_grad+= hz_grad * 1.0 / 5.0
+
+    bh_cell, bu_edge, hz_grad = step_BT32(
+        mesh, trsk, flow, cnfg , bh_cell, bu_edge, ru_edge)
+
+    bt_grad+= hz_grad * 1.0 / 5.0
+
+    bh_cell, bu_edge, hz_grad = step_BT32(
+        mesh, trsk, flow, cnfg , bh_cell, bu_edge, ru_edge)
+
+    bt_grad+= hz_grad * 1.0 / 5.0
+
+    bh_cell, bu_edge, hz_grad = step_BT32(
+        mesh, trsk, flow, cnfg , bh_cell, bu_edge, ru_edge)
+
+    bt_grad+= hz_grad * 1.0 / 5.0
+
+    bh_cell, bu_edge, hz_grad = step_BT32(
+        mesh, trsk, flow, cnfg , bh_cell, bu_edge, ru_edge)
+
+    bt_grad+= hz_grad * 1.0 / 5.0
+
+#-- correct onto long time-step; advance to (h3,u3)
+
+    h3_cell = bh_cell
+    u3_edge = uu_edge - 1.0 / 1.0 * cnfg.time_step * (
+        1.0 * bt_grad + 
+            ke_grad + qh_flux - uu_damp
+    )
+
+    return h3_cell, u3_edge, ke_cell, ke_dual, \
+           rv_cell, pv_cell, \
+           rv_dual, pv_dual, ke_bias, pv_bias
+
+
+def step_SP33(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
+
+#-- standard SSP-RK(3,3) method:
+
+    ff_cell = flow.ff_cell
+    ff_edge = flow.ff_edge
+    ff_dual = flow.ff_vert
+
+    zb_cell = flow.zb_cell
+
+#-- 1st RK + FB stage
+
+    ttic = time.time()
+
+    vv_edge = trsk.edge_lsqr_perp * uu_edge
+
+    hh_dual, \
+    hh_edge = compute_H(mesh, trsk, cnfg, hh_cell, uu_edge)
+
+    uh_edge = uu_edge * hh_edge
+
+    uh_cell = trsk.cell_flux_sums * uh_edge
+    uh_cell/= mesh.cell.area
+
+    h1_cell = (
+        hh_cell - 1.0 / 1.0 * cnfg.time_step * uh_cell
+    )
+
+    ttoc = time.time()
+    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
+
+    ttic = time.time()
+
+    ke_dual, ke_cell, __ = computeKE(
+        mesh, trsk, cnfg, 
+        hh_cell, hh_edge, hh_dual, 
+        uu_edge, vv_edge,
+        +1.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
+
+    hk_cell = hh_cell + zb_cell 
+    hk_cell = ke_cell + hk_cell * flow.grav
+
+    hk_grad = trsk.edge_grad_norm * hk_cell
+
+    rv_dual, pv_dual, rv_cell, pv_cell, \
+    pv_edge, __ = computePV(
+        mesh, trsk, cnfg, 
+        hh_cell, hh_edge, hh_dual, uu_edge, vv_edge, 
+        ff_dual, ff_edge, ff_cell, 
+        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
+
+    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
+
+    uu_damp = computeDU(mesh, trsk, cnfg, uu_edge)
+
+    u1_edge = uu_edge - 1.0 / 1.0 * cnfg.time_step * (
+        hk_grad + qh_flux - uu_damp
+    )
+
+    ttoc = time.time()
+    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
+
+#-- 2nd RK + FB stage
+
+    ttic = time.time()
+
+    v1_edge = trsk.edge_lsqr_perp * u1_edge
+
+    h1_dual, \
+    h1_edge = compute_H(mesh, trsk, cnfg, h1_cell, u1_edge)
+
+    uh_edge = u1_edge * h1_edge
+
+    uh_cell = trsk.cell_flux_sums * uh_edge
+    uh_cell/= mesh.cell.area
+
+    h2_cell = (
+        3.0 / 4.0 * hh_cell + 
+        1.0 / 4.0 * h1_cell - 
+            1.0 / 4.0 * cnfg.time_step * uh_cell
+    )
+
+    ttoc = time.time()
+    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
+
+    ttic = time.time()
+
+    ke_dual, ke_cell, __ = computeKE(
+        mesh, trsk, cnfg, 
+        h1_cell, h1_edge, h1_dual, 
+        u1_edge, v1_edge,
+        +1.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
+
+    hk_cell = h1_cell + zb_cell 
+    hk_cell = ke_cell + hk_cell * flow.grav
+
+    hk_grad = trsk.edge_grad_norm * hk_cell
+
+    rv_dual, pv_dual, rv_cell, pv_cell, \
+    pv_edge, __ = computePV(
+        mesh, trsk, cnfg, 
+        h1_cell, h1_edge, h1_dual, u1_edge, v1_edge, 
+        ff_dual, ff_edge, ff_cell, 
+        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
+
+    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
+
+    uu_damp = computeDU(mesh, trsk, cnfg, u1_edge)
+
+    u2_edge = (
+        3.0 / 4.0 * uu_edge +
+        1.0 / 4.0 * u1_edge - 
+            1.0 / 4.0 * cnfg.time_step * (
+                hk_grad + qh_flux - uu_damp
+    ))
+
+    ttoc = time.time()
+    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
+
+#-- 3rd RK + FB stage
+
+    ttic = time.time()
+
+    v2_edge = trsk.edge_lsqr_perp * u2_edge
+
+    h2_dual, \
+    h2_edge = compute_H(mesh, trsk, cnfg, h2_cell, u2_edge)
+
+    uh_edge = u2_edge * h2_edge
+
+    uh_cell = trsk.cell_flux_sums * uh_edge
+    uh_cell/= mesh.cell.area
+
+    h3_cell = (
+        1.0 / 3.0 * hh_cell +
+        2.0 / 3.0 * h2_cell - 
+            2.0 / 3.0 * cnfg.time_step * uh_cell
+    )
+
+    ttoc = time.time()
+    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
+
+    ttic = time.time()
+
+    ke_dual, ke_cell, ke_bias = computeKE(
+        mesh, trsk, cnfg, 
+        h2_cell, h2_edge, h2_dual, 
+        u2_edge, v2_edge,
+        +1.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
+
+    hk_cell = h2_cell + zb_cell 
+    hk_cell = ke_cell + hk_cell * flow.grav
+
+    hk_grad = trsk.edge_grad_norm * hk_cell
+
+    rv_dual, pv_dual, rv_cell, pv_cell, \
+    pv_edge, pv_bias = computePV(
+        mesh, trsk, cnfg, 
+        h2_cell, h2_edge, h2_dual, u2_edge, v2_edge, 
+        ff_dual, ff_edge, ff_cell, 
+        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
+
+    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
+
+    uu_damp = computeDU(mesh, trsk, cnfg, u2_edge)
+
+    u3_edge = (
+        1.0 / 3.0 * uu_edge +
+        2.0 / 3.0 * u2_edge - 
+            2.0 / 3.0 * cnfg.time_step * (
+                hk_grad + qh_flux - uu_damp
+    ))
+
+    ttoc = time.time()
+    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
+
+    return h3_cell, u3_edge, ke_cell, ke_dual, \
+           rv_cell, pv_cell, \
+           rv_dual, pv_dual, ke_bias, pv_bias
+
+

--- a/_dx.py
+++ b/_dx.py
@@ -1,0 +1,603 @@
+
+import time
+import numpy as np
+
+#-- SWE spatial discretisation using TRSK-like operators
+#--
+#-- Darren Engwirda
+
+HH_TINY        = 1.0E-02
+UU_TINY        = 1.0E-16
+
+class base: pass
+tcpu = base()
+tcpu.thickness = 0.0E+00
+tcpu.momentum_ = 0.0E+00
+tcpu.upwinding = 0.0E+00
+tcpu.compute_H = 0.0E+00
+tcpu.computeKE = 0.0E+00
+tcpu.computePV = 0.0E+00
+tcpu.advect_PV = 0.0E+00
+tcpu.computeDU = 0.0E+00
+
+def hrmn_mean(xone, xtwo):
+
+#-- harmonic mean of two vectors (ie. biased toward lesser)
+
+    return +2.0 * xone * xtwo / (xone + xtwo)
+
+
+def invariant(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
+
+#-- compute the discrete energy and enstrophy invariants
+
+    ff_dual = flow.ff_vert
+    ff_edge = flow.ff_edge
+    ff_cell = flow.ff_cell
+
+    zb_cell = flow.zb_cell
+
+    vv_edge = trsk.edge_lsqr_perp * uu_edge * +1.
+
+    hh_dual, \
+    hh_edge = compute_H(mesh, trsk, cnfg, hh_cell, uu_edge)
+
+    ke_edge =  0.5 * uu_edge ** 2
+
+    ke_edge = ke_edge * hh_edge * mesh.edge.clen \
+                                * mesh.edge.vlen
+
+    pe_cell = flow.grav * (hh_cell * 0.5 + zb_cell)
+
+    pe_cell = pe_cell * hh_cell * mesh.cell.area
+
+    kk_sums = np.sum(ke_edge) + np.sum(pe_cell)
+
+    rv_dual, pv_dual, rv_cell, pv_cell, \
+    pv_edge, __ = computePV(
+        mesh, trsk, cnfg, 
+        hh_cell, hh_edge, hh_dual, uu_edge, vv_edge,
+        ff_dual, ff_edge, ff_cell, 
+        +0.0 * cnfg.time_step, 0.0 * cnfg.pv_upwind)
+
+   #pv_sums = np.sum(
+   #    +0.5 * mesh.edge.area * hh_edge * pv_edge ** 2)
+
+    pv_sums = np.sum(
+        +0.5 * mesh.vert.area * hh_dual * pv_dual ** 2)
+
+    return kk_sums, pv_sums
+
+
+def upwinding(mesh, trsk, cnfg, 
+              sv_dual, sm_dual, sv_cell, sv_edge,
+              uu_edge, vv_edge, 
+              delta_t, up_bias):
+
+    ttic = time.time()
+
+    if (cnfg.up_scheme == "LUST"):
+
+    #-- upwind bias, a'la Weller
+    #-- H. Weller (2012): Controlling the computational modes 
+    #-- of the arbitrarily structured C grid
+    #-- https://doi.org/10.1175/MWR-D-11-00221.1
+        dv_edge = trsk.edge_grad_perp * sv_dual
+
+        dx_dual = trsk.dual_lsqr_xprp * dv_edge
+        dy_dual = trsk.dual_lsqr_yprp * dv_edge
+        dz_dual = trsk.dual_lsqr_zprp * dv_edge
+
+        sv_bias = np.zeros(mesh.edge.size)
+
+        up_edge = np.where(vv_edge <= 0.0)
+        dn_edge = np.where(vv_edge >= 0.0)
+
+        up_dual = np.zeros(
+            mesh.edge.size, dtype=np.int32)
+        up_dual[up_edge] = \
+            mesh.edge.vert[up_edge, 1] - 1
+        up_dual[dn_edge] = \
+            mesh.edge.vert[dn_edge, 0] - 1
+
+        up_xdel = \
+            mesh.edge.xpos - mesh.vert.xmid[up_dual]
+        up_ydel = \
+            mesh.edge.ypos - mesh.vert.ymid[up_dual]
+        up_zdel = \
+            mesh.edge.zpos - mesh.vert.zmid[up_dual]
+
+        va_edge = np.abs(vv_edge) + UU_TINY
+        ua_edge = np.abs(uu_edge) + UU_TINY
+        
+        BIAS = (
+            up_bias * va_edge / (ua_edge + va_edge)
+        )
+
+        sv_wind = sv_dual[up_dual] + \
+            up_xdel * dx_dual[up_dual] + \
+            up_ydel * dy_dual[up_dual] + \
+            up_zdel * dz_dual[up_dual]
+
+        sv_edge = \
+            BIAS * sv_wind + (1.0 - BIAS) * sv_edge
+
+    if (cnfg.up_scheme == "APVM"):
+
+        dn_edge = trsk.edge_grad_norm * sv_cell
+        dp_edge = trsk.edge_grad_perp * sv_dual
+
+        sv_bias = np.zeros(mesh.edge.size)
+
+    #-- upwind APVM, scale w time
+        up_bias = 1.0                   # hard-coded?
+        sv_apvm = up_bias * uu_edge * dn_edge + \
+                  up_bias * vv_edge * dp_edge
+
+        sv_edge = sv_edge - delta_t * sv_apvm
+        
+    if (cnfg.up_scheme == "UUST"):
+
+        dn_edge = trsk.edge_grad_norm * sv_cell
+        dp_edge = trsk.edge_grad_perp * sv_dual
+
+        sv_bias = np.zeros(mesh.edge.size)
+
+    #-- upwind APVM, scale w grid
+        um_edge = UU_TINY + \
+            np.sqrt(uu_edge ** 2 + vv_edge ** 2)
+
+        sv_wind = uu_edge * dn_edge / um_edge + \
+                  vv_edge * dp_edge / um_edge
+
+        ee_scal = mesh.edge.slen
+
+        sv_edge-= up_bias * ee_scal * sv_wind
+
+    if (cnfg.up_scheme == "AUST"):
+        
+    #-- AUST: anticipated upstream method; APVM meets
+    #-- LUST? Upwinds in multi-dimensional sense, vs.
+    #-- LUST, which upwinds via tangential dir. only.
+
+        dn_edge = trsk.edge_grad_norm * sv_cell
+        dp_edge = trsk.edge_grad_perp * sv_dual
+
+        dm_edge = 0.5 * (
+            np.abs(dn_edge * mesh.edge.clen) +
+            np.abs(dp_edge * mesh.edge.vlen)
+        )
+
+        dm_vert = \
+            (trsk.dual_edge_sums * dm_edge) / 3.
+
+        ds_dual = np.abs(
+            sv_dual - sm_dual) / (dm_vert + UU_TINY)
+
+        ds_dual = ds_dual ** 2
+
+        sv_bias = np.sqrt(
+            (trsk.edge_vert_sums * ds_dual) / 2.
+        )
+
+
+       #ds_edge = \
+       #    (trsk.edge_vert_sums * ds_dual) / 2.
+       
+       #sv_bias = ds_edge / (dm_edge + UU_TINY)
+
+    #-- upwind APVM, scale w grid
+        um_edge = UU_TINY + \
+            np.sqrt(uu_edge ** 2 + vv_edge ** 2)
+
+        sv_wind = uu_edge * dn_edge / um_edge + \
+                  vv_edge * dp_edge / um_edge
+
+        ee_scal = mesh.edge.slen
+
+        sv_bias = up_bias \
+            + np.minimum(+3./8. - up_bias, sv_bias)
+
+        sv_edge-= sv_bias * ee_scal * sv_wind
+
+    ttoc = time.time()
+    tcpu.upwinding = tcpu.upwinding + (ttoc - ttic)
+
+    return sv_edge, sv_bias
+
+
+def compute_H(mesh, trsk, cnfg, hh_cell, uu_edge):
+
+    ttic = time.time()
+
+    if (cnfg.operators == "TRSK-CV"):
+
+        hh_dual = trsk.dual_kite_sums * hh_cell
+        hh_dual/= mesh.vert.area
+
+        hh_edge = trsk.edge_wing_sums * hh_cell
+        hh_edge/= mesh.edge.area
+
+    if (cnfg.operators == "TRSK-MD"):
+
+        hh_dual = trsk.dual_kite_sums * hh_cell
+        hh_dual/= mesh.vert.area
+
+        hh_edge = trsk.edge_cell_sums * hh_cell
+        hh_edge*= 0.5E+00
+
+    ttoc = time.time()
+    tcpu.compute_H = tcpu.compute_H + (ttoc - ttic)
+
+    return hh_dual, hh_edge
+
+
+def computePV(mesh, trsk, cnfg, 
+              hh_cell, hh_edge, hh_dual, uu_edge, vv_edge, 
+              ff_dual, ff_edge, ff_cell,
+              delta_t, up_bias):
+
+    ttic = time.time()
+
+    if (cnfg.operators == "TRSK-CV"):
+
+    #-- RV+f on rhombi, PV on edge - more compact stencil?        
+        rv_dual = trsk.dual_curl_sums * uu_edge
+        rv_dual/= mesh.vert.area
+        
+        av_dual = rv_dual + ff_dual
+        pv_dual = av_dual / hh_dual
+        
+        rv_cell = trsk.cell_kite_sums * rv_dual
+        rv_cell/= mesh.cell.area
+
+        av_cell = rv_cell + ff_cell
+        pv_cell = av_cell / hh_cell
+
+    #-- compute curl on rhombi -- a'la Gassmann
+        rm_edge = trsk.quad_curl_sums * uu_edge
+        rm_edge/= mesh.quad.area
+
+        hv_edge = trsk.edge_stub_sums * hh_dual
+        hv_edge/= mesh.edge.area
+
+        hm_edge = 1. / 2. * hh_edge \
+                + 1. / 2. * hv_edge
+        
+        am_edge = rm_edge + ff_edge
+        pm_edge = am_edge / hm_edge
+
+    #-- average rhombi to dual -- a'la Gassmann
+        rm_dual = trsk.dual_edge_sums * rm_edge / 3.0
+
+        am_dual = rm_dual + ff_dual
+        pm_dual = am_dual / hh_dual
+
+    #-- compute high(er)-order RV + PV on edges:
+    #-- pv_edge = pv_dual + (xe - xv) * pv_d/dx
+        pv_edge = trsk.edge_vert_sums * pv_dual / 2.0
+        pv_edge+= trsk.edge_dual_reco * pm_dual
+
+        pv_edge = 3. / 8. * pv_edge \
+                + 5. / 8. * pm_edge
+
+        pv_edge, up_edge = upwinding(
+            mesh, trsk, cnfg, 
+            pv_dual, pm_dual, pv_cell, pv_edge,
+            uu_edge, vv_edge, delta_t, up_bias)
+
+    if (cnfg.operators == "TRSK-MD"):
+
+        rv_dual = trsk.dual_curl_sums * uu_edge
+        rv_dual/= mesh.vert.area
+
+        av_dual = rv_dual + ff_dual
+        pv_dual = av_dual / hh_dual
+
+        rv_cell = trsk.cell_kite_sums * rv_dual
+        rv_cell/= mesh.cell.area
+
+        av_cell = rv_cell + ff_cell
+        pv_cell = av_cell / hh_cell
+
+        rv_edge = trsk.edge_vert_sums * rv_dual / 2.0
+        pv_edge = trsk.edge_vert_sums * pv_dual / 2.0
+        
+        rm_dual = trsk.dual_edge_sums * rv_edge / 3.0
+        
+        am_dual = rm_dual + ff_dual
+        pm_dual = am_dual / hh_dual
+
+        pv_edge, up_edge = upwinding(
+            mesh, trsk, cnfg, 
+            pv_dual, pm_dual, pv_cell, pv_edge, 
+            uu_edge, vv_edge, delta_t, up_bias)
+
+    ttoc = time.time()
+    tcpu.computePV = tcpu.computePV + (ttoc - ttic)
+
+    return rv_dual, pv_dual, rv_cell, pv_cell, \
+           pv_edge, up_edge
+
+
+"""
+def computeKE(mesh, trsk, cnfg, 
+              hh_cell, hh_edge, hh_dual, uu_edge, vv_edge,
+              delta_t, up_bias):
+
+    ttic = time.time()
+
+    if (cnfg.operators == "TRSK-CV"):
+
+        up_edge = np.zeros(mesh.edge.size, dtype=float)
+
+        if ("WEIGHT" in cnfg.ke_scheme):
+
+            hh_thin = 1.0E+02
+
+            ke_edge = 0.5 * (uu_edge ** 2 + 
+                             vv_edge ** 2 )
+ 
+            hh_scal = hh_thin / hh_edge
+
+            ke_edge*= ((1.0 + hh_scal) ** 2) ** 2
+
+            ke_cell = trsk.cell_wing_sums * ke_edge
+            ke_cell/= mesh.cell.area
+
+            ke_dual = trsk.dual_stub_sums * ke_edge
+            ke_dual/= mesh.vert.area
+
+            hh_scal = hh_thin / hh_cell
+
+            ke_cell/= ((1.0 + hh_scal) ** 2) ** 2
+
+        else:  # CENTRE
+
+            ke_edge = 0.5 * (uu_edge ** 2 + 
+                             vv_edge ** 2 )
+
+            ke_dual = trsk.dual_stub_sums * ke_edge
+            ke_dual/= mesh.vert.area
+
+            ke_cell = trsk.cell_wing_sums * ke_edge
+            ke_cell/= mesh.cell.area
+
+    if (cnfg.operators == "TRSK-MD"):
+
+        up_edge = np.zeros(mesh.edge.size, dtype=float)
+
+        if ("WEIGHT" in cnfg.ke_scheme):
+
+            hh_thin = 1.0E+02
+
+            ke_edge = 0.25 * uu_edge ** 2 * \
+                  mesh.edge.clen * \
+                  mesh.edge.vlen
+
+            hh_scal = hh_thin / hh_edge
+
+            ke_edge*= ((1.0 + hh_scal) ** 2) ** 2
+
+            ke_cell = trsk.cell_edge_sums * ke_edge
+            ke_cell/= mesh.cell.area
+
+            ke_dual = trsk.dual_edge_sums * ke_edge
+            ke_dual/= mesh.vert.area
+
+            hh_scal = hh_thin / hh_cell
+
+            ke_cell/= ((1.0 + hh_scal) ** 2) ** 2
+
+        else:  # CENTRE
+
+            ke_edge = 0.25 * uu_edge ** 2 * \
+                  mesh.edge.clen * \
+                  mesh.edge.vlen
+
+            ke_dual = trsk.dual_edge_sums * ke_edge
+            ke_dual/= mesh.vert.area
+
+            ke_cell = trsk.cell_edge_sums * ke_edge
+            ke_cell/= mesh.cell.area
+
+    ttoc = time.time()
+    tcpu.computeKE = tcpu.computeKE + (ttoc - ttic)
+
+    return ke_dual, ke_cell, up_edge
+"""
+
+
+def computeKE(mesh, trsk, cnfg, 
+              hh_cell, hh_edge, hh_dual, uu_edge, vv_edge,
+              delta_t, up_bias):
+
+    ttic = time.time()
+
+    if (cnfg.operators == "TRSK-CV"):
+
+        up_edge = np.zeros(mesh.edge.size, dtype=float)
+
+        if ("CENTRE" in cnfg.ke_scheme):
+
+            ke_edge = 0.5 * (uu_edge ** 2 + 
+                             vv_edge ** 2 )
+
+        if ("UPWIND" in cnfg.ke_scheme):
+
+            ke_edge = 0.5 * (uu_edge ** 2 + 
+                             vv_edge ** 2 )
+
+            ux_dual = trsk.dual_lsqr_xnrm * uu_edge
+            uy_dual = trsk.dual_lsqr_ynrm * uu_edge
+            uz_dual = trsk.dual_lsqr_znrm * uu_edge
+
+            ke_dual = 0.5 * (ux_dual ** 2 + 
+                             uy_dual ** 2 + 
+                             uz_dual ** 2 )
+            
+            ke_cell = trsk.cell_kite_sums * ke_dual
+            ke_cell/= mesh.cell.area
+
+            ke_edge, up_edge = upwinding(
+                mesh, trsk, cnfg, 
+                ke_dual, ke_dual, ke_cell, ke_edge, 
+                uu_edge, vv_edge, delta_t, up_bias)
+
+        if ("WEIGHT" in cnfg.ke_scheme):
+
+            hh_thin = 1.0E+02
+            hh_tiny = 1.0E-08
+ 
+            hh_scal = \
+                limit_div(hh_thin, hh_edge, hh_tiny)
+
+            ke_edge = ke_edge * \
+                ((1.0 + hh_scal) ** 2) ** 2
+
+            ke_dual = trsk.dual_stub_sums * ke_edge
+            ke_dual/= mesh.vert.area
+
+            ke_cell = trsk.cell_wing_sums * ke_edge
+            ke_cell/= mesh.cell.area
+
+            hh_scal = \
+                limit_div(hh_thin, hh_cell, hh_tiny)
+
+            ke_cell = ke_cell / \
+                ((1.0 + hh_scal) ** 2) ** 2
+
+        else:
+
+            ke_cell = trsk.cell_wing_sums * ke_edge
+            ke_cell/= mesh.cell.area
+
+            ke_dual = trsk.dual_stub_sums * ke_edge
+            ke_dual/= mesh.vert.area
+
+    if (cnfg.operators == "TRSK-MD"):
+
+        up_edge = np.zeros(mesh.edge.size, dtype=float)
+
+        if ("CENTRE" in cnfg.ke_scheme):
+
+            ke_edge = 0.25 * uu_edge ** 2 * \
+                  mesh.edge.clen * \
+                  mesh.edge.vlen
+
+        if ("UPWIND" in cnfg.ke_scheme):
+
+            ke_edge = 1.00 * uu_edge ** 2
+
+            ux_dual = trsk.dual_lsqr_xnrm * uu_edge
+            uy_dual = trsk.dual_lsqr_ynrm * uu_edge
+            uz_dual = trsk.dual_lsqr_znrm * uu_edge
+
+            ke_dual = 0.5 * (ux_dual ** 2 + 
+                             uy_dual ** 2 + 
+                             uz_dual ** 2 )
+            
+            ke_cell = trsk.cell_kite_sums * ke_dual
+            ke_cell/= mesh.cell.area
+
+            ke_edge, up_edge = upwinding(
+                mesh, trsk, cnfg, 
+                ke_dual, ke_dual, ke_cell, ke_edge, 
+                uu_edge, vv_edge, delta_t, up_bias)
+
+            ke_edge = 0.25 * ke_edge ** 1 * \
+                  mesh.edge.clen * \
+                  mesh.edge.vlen
+
+        if ("WEIGHT" in cnfg.ke_scheme):
+
+            hh_thin = 1.0E+02
+            hh_tiny = 1.0E-08
+
+            hs_edge = trsk.edge_vert_sums * hh_dual
+            hs_edge*= 0.5E+00
+            
+            hh_scal = \
+                limit_div(hh_thin, hs_edge, hh_tiny)
+
+            ke_edge = ke_edge * \
+                ((1.0 + hh_scal) ** 2) ** 2
+
+            ke_dual = trsk.dual_edge_sums * ke_edge
+            ke_dual/= mesh.vert.area
+
+            ke_cell = trsk.cell_edge_sums * ke_edge
+            ke_cell/= mesh.cell.area
+
+            hh_scal = \
+                limit_div(hh_thin, hh_cell, hh_tiny)
+
+            ke_cell = ke_cell / \
+                ((1.0 + hh_scal) ** 2) ** 2
+
+        else:
+
+            ke_cell = trsk.cell_edge_sums * ke_edge
+            ke_cell/= mesh.cell.area
+
+            ke_dual = trsk.dual_edge_sums * ke_edge
+            ke_dual/= mesh.vert.area
+
+
+    ttoc = time.time()
+    tcpu.computeKE = tcpu.computeKE + (ttoc - ttic)
+
+    return ke_dual, ke_cell, up_edge
+
+
+def advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge):
+
+    ttic = time.time()
+
+    pv_flux = (
+        trsk.edge_flux_perp * (pv_edge * uh_edge) +
+        pv_edge * (trsk.edge_flux_perp * uh_edge)
+    )
+
+    ttoc = time.time()
+    tcpu.advect_PV = tcpu.advect_PV + (ttoc - ttic)
+
+    return pv_flux * -0.50
+
+
+def computeDU(mesh, trsk, cnfg, uu_edge):
+
+#-- Divergence(-only) dissipation
+
+    if (cnfg.du_damp_2 == 0 and 
+        cnfg.du_damp_4 == 0):
+        return np.zeros(mesh.edge.size, dtype=float)
+
+    ttic = time.time()
+
+#-- div(u.n)
+    du_cell = trsk.cell_flux_sums * uu_edge
+    du_cell/= mesh.cell.area
+    
+    d2_cell = du_cell * cnfg.du_damp_2
+    d4_cell = du_cell * cnfg.du_damp_4  # NB. sqrt(vk)
+
+#-- D^2 = grad(vk * div(u.n))
+    d2_edge = trsk.edge_grad_norm * d2_cell
+    d4_edge = trsk.edge_grad_norm * d4_cell
+
+#-- div(D^2)
+    du_cell = trsk.cell_flux_sums * d4_edge
+    du_cell/= mesh.cell.area
+    
+    d4_cell = du_cell * cnfg.du_damp_4  # NB. sqrt(vk)
+
+#-- D^4 = grad(vk * div(D^2))
+    d4_edge = trsk.edge_grad_norm * d4_cell
+    
+    ttoc = time.time()
+    tcpu.computeDU = tcpu.computeDU + (ttoc - ttic)
+
+    return d2_edge - d4_edge
+
+

--- a/jet.py
+++ b/jet.py
@@ -46,20 +46,20 @@ def init(name, save, rsph=1.E+0, pert=True):
 
 #------------------------------------ load an MPAS mesh file
 
-    print("Load the mesh file")
+    print("Loading the mesh file...")
 
     mesh = load_mesh(name, rsph)
     
 #------------------------------------ build TRSK matrix op's
 
-    print("Forming coefficients")
+    print("Forming coefficients...")
 
     trsk = trsk_mats(mesh)
 
 #------------------------------------ build a streamfunction
 
-    print("Build streamfunction")
-
+    print("Computing streamfunction...")
+    
 #-- J. Galewsky, R.K. Scott & L.M. Polvani (2004) An initial
 #-- value problem for testing numerical models of the global
 #-- shallow-water equations, Tellus A: Dynamic Meteorology &
@@ -118,7 +118,7 @@ def init(name, save, rsph=1.E+0, pert=True):
 #-- Computational Modes and Grid Imprinting on Five Quasi-
 #-- Uniform Spherical C-Grids, M.Wea.Rev. 140(8): 2734-2755.
 
-    print("Calc. velocity field")
+    print("Computing velocity field...")
 
     unrm = trsk.edge_grad_perp * vpsi * -1.00
 
@@ -133,7 +133,7 @@ def init(name, save, rsph=1.E+0, pert=True):
 #-- solve -g * del^2 h = div f * u_perp for layer thickness,
 #-- leads to a h which is in discrete balance
 
-    print("Find layer thickness")
+    print("Coputing layer thickness...")
 
     frot = 2.0 * erot * np.sin(mesh.edge.ylat)
 

--- a/jet.py
+++ b/jet.py
@@ -133,7 +133,7 @@ def init(name, save, rsph=1.E+0, pert=True):
 #-- solve -g * del^2 h = div f * u_perp for layer thickness,
 #-- leads to a h which is in discrete balance
 
-    print("Coputing layer thickness...")
+    print("Computing flow thickness...")
 
     frot = 2.0 * erot * np.sin(mesh.edge.ylat)
 

--- a/map.py
+++ b/map.py
@@ -5,6 +5,7 @@ import numpy as np
 import netCDF4 as nc
 import argparse
 
+#-- Output MPAS-style *.vtk, requires MPAS-Tools
 
 if (__name__ == "__main__"):
     parser = argparse.ArgumentParser(

--- a/ops.py
+++ b/ops.py
@@ -24,17 +24,29 @@ def trsk_mats(mesh):
     EDGE-GRAD-NORM: edge gradient (normal)
     EDGE-GRAD-PERP: edge gradient (perpendicular)
 
-    DUAL-CURL-SUMS: curl integration (* area)
+    DUAL-FLUX-SUMS: div. integration (* area)
     DUAL-KITE-SUMS: cell-to-dual remapping
     DUAL-STUB-SUMS: edge-to-dual remapping
     DUAL-CELL-SUMS: cell-to-dual summation
     DUAL-EDGE-SUMS: edge-to-dual summation
+    DUAL-CURL-SUMS: curl integration (* area)    
     DUAL-DEL2-SUMS: dual del-squared (* area)
 
     QUAD-CURL-SUMS: curl integration (* area)
 
-    EDGE-FLUX-PERP: reconstruct u (perpendicular)
-    EDGE-LSQR-PERP: reconstruct u (perpendicular)
+    EDGE-FLUX-PERP: reconstruct v (perpendicular)
+    EDGE-LSQR-PERP: reconstruct v (perpendicular)
+    EDGE-LSQR-NORM: reconstruct u (perpendicular)
+
+    (from norm. components)
+    DUAL-LSQR-XNRM: reconstruct U (cartesian)
+    DUAL-LSQR-YNRM: reconstruct Y (cartesian)
+    DUAL-LSQR-ZNRM: reconstruct Z (cartesian)
+
+    (from perp. components)
+    DUAL-LSQR-XPRP: reconstruct U (cartesian)
+    DUAL-LSQR-YPRP: reconstruct Y (cartesian)
+    DUAL-LSQR-ZPRP: reconstruct Z (cartesian)
 
     (from norm. components)
     CELL-LSQR-XNRM: reconstruct U (cartesian)
@@ -46,15 +58,14 @@ def trsk_mats(mesh):
     EDGE-LSQR-YNRM: reconstruct Y (cartesian)
     EDGE-LSQR-ZNRM: reconstruct Z (cartesian)
 
-    (from norm. components)
-    DUAL-LSQR-XNRM: reconstruct U (cartesian)
-    DUAL-LSQR-YNRM: reconstruct Y (cartesian)
-    DUAL-LSQR-ZNRM: reconstruct Z (cartesian)
-
     (from perp. components)
-    DUAL-LSQR-XPRP: reconstruct U (cartesian)
-    DUAL-LSQR-YPRP: reconstruct Y (cartesian)
-    DUAL-LSQR-ZPRP: reconstruct Z (cartesian)
+    EDGE-LSQR-XPRP: reconstruct U (cartesian)
+    EDGE-LSQR-YPRP: reconstruct Y (cartesian)
+    EDGE-LSQR-ZPRP: reconstruct Z (cartesian)
+
+    (piecewise linear op's)
+    EDGE-DUAL-RECO: recon. F at edge from dual
+    EDGE-CELL-RECO: recon. F at edge from cell
 
     """
     # Authors: Darren Engwirda
@@ -70,7 +81,8 @@ def trsk_mats(mesh):
     trsk.cell_wing_sums = cell_wing_sums(mesh)
     trsk.cell_edge_sums = cell_edge_sums(mesh)
     trsk.cell_vert_sums = cell_vert_sums(mesh)
-    trsk.cell_curl_sums = cell_curl_sums(mesh)
+   #trsk.cell_curl_sums = cell_curl_sums(mesh)
+    trsk.cell_curl_sums = trsk.cell_flux_sums  # equiv.
 
     trsk.edge_stub_sums = edge_stub_sums(mesh)
     trsk.edge_wing_sums = edge_wing_sums(mesh)
@@ -82,13 +94,16 @@ def trsk_mats(mesh):
     trsk.cell_del2_sums = trsk.cell_flux_sums \
                         * trsk.edge_grad_norm
 
-    trsk.dual_curl_sums = dual_curl_sums(mesh)
+    trsk.dual_flux_sums = dual_flux_sums(mesh)
     trsk.dual_kite_sums = dual_kite_sums(mesh)
     trsk.dual_stub_sums = dual_stub_sums(mesh)
     trsk.dual_cell_sums = dual_cell_sums(mesh)
     trsk.dual_edge_sums = dual_edge_sums(mesh)
+   #trsk.dual_curl_sums = dual_curl_sums(mesh)
+    trsk.dual_curl_sums = trsk.dual_flux_sums  # equiv.
 
-    trsk.dual_del2_sums = dual_del2_sums(mesh)
+    trsk.dual_del2_sums = trsk.dual_flux_sums \
+                        * trsk.edge_grad_perp
 
     # take curl on rhombi, a'la Gassmann
     trsk.quad_curl_sums = trsk.edge_vert_sums \
@@ -96,21 +111,25 @@ def trsk_mats(mesh):
     trsk.quad_curl_sums.setdiag(0.0)
     trsk.quad_curl_sums.eliminate_zeros()
 
-    trsk.cell_lsqr_xnrm, \
-    trsk.cell_lsqr_ynrm, \
-    trsk.cell_lsqr_znrm = cell_lsqr_fxyz(mesh)
-
-    trsk.edge_lsqr_xnrm, \
-    trsk.edge_lsqr_ynrm, \
-    trsk.edge_lsqr_znrm = edge_lsqr_fxyz(mesh)
-    
+    # least-squares vector reconstruction operators
     trsk.dual_lsqr_xnrm, \
     trsk.dual_lsqr_ynrm, \
     trsk.dual_lsqr_znrm, \
     trsk.dual_lsqr_xprp, \
     trsk.dual_lsqr_yprp, \
     trsk.dual_lsqr_zprp = dual_lsqr_fxyz(mesh)
- 
+
+    trsk.cell_lsqr_xnrm, \
+    trsk.cell_lsqr_ynrm, \
+    trsk.cell_lsqr_znrm = cell_lsqr_fxyz(mesh)
+
+    trsk.edge_lsqr_xnrm, \
+    trsk.edge_lsqr_ynrm, \
+    trsk.edge_lsqr_znrm, \
+    trsk.edge_lsqr_xprp, \
+    trsk.edge_lsqr_yprp, \
+    trsk.edge_lsqr_zprp = edge_lsqr_fxyz(mesh)
+    
     # ensure flux reconstruction operator is exactly
     # skew-symmetric. Per Ringler et al, 2010, W_prp
     # is required to be anti-symmetric to ensure
@@ -169,12 +188,23 @@ def trsk_mats(mesh):
     mesh.quad.area = \
         trsk.edge_vert_sums * mesh.vert.area
 
-    # build LSQR-PERP from edge-wise reconstructions
+    # build LSQR-<OP> from edge-wise reconstructions
     trsk.edge_lsqr_perp = +1.0 * (
         mesh.edge.xprp * trsk.edge_lsqr_xnrm +
         mesh.edge.yprp * trsk.edge_lsqr_ynrm +
         mesh.edge.zprp * trsk.edge_lsqr_znrm 
     )
+
+    trsk.edge_lsqr_norm = +1.0 * (
+        mesh.edge.xnrm * trsk.edge_lsqr_xprp +
+        mesh.edge.ynrm * trsk.edge_lsqr_yprp +
+        mesh.edge.znrm * trsk.edge_lsqr_zprp 
+    )
+
+    # operators for piecewise linear reconstructions
+    # fe = fi + (xe - xi) * grad(f)
+    trsk.edge_dual_reco = edge_dual_reco(mesh, trsk)
+    trsk.edge_cell_reco = edge_cell_reco(mesh, trsk)
 
     return trsk
 
@@ -440,7 +470,7 @@ def edge_grad_norm(mesh):
 
 def edge_grad_perp(mesh):
 
-#-- EDGE-GRAD-PERP: returns (V(j)-V(i))/eij as sparse matrix
+#-- EDGE-GRAD-PERP: returns (V(j)-V(i))/vij as sparse matrix
 #-- operator OP. Use GRAD(V) = OP * V where V is a vector of
 #-- node-centred scalars for all nodes in the mesh.
 
@@ -457,12 +487,6 @@ def edge_grad_perp(mesh):
         (-1.E+0 / vlen, +1.E+0 / vlen))
     
     return csr_matrix((xvec, (ivec, jvec)))
-
-
-def edge_vals_perp(mesh):
-
-
-    return wmul
 
 
 def edge_flux_perp(mesh):
@@ -514,6 +538,36 @@ def dual_edge_sign(mesh):
         sign[flip, edge] = -1
 
     return sign
+
+
+def dual_flux_sums(mesh):
+
+    xvec = np.array([], dtype=np.float64)
+    ivec = np.array([], dtype=np.int32)
+    jvec = np.array([], dtype=np.int32)
+
+    for edge in range(3):
+
+        vidx = np.arange(0, mesh.vert.size)
+
+        eidx = mesh.vert.edge[:, edge] - 1
+        cidx = mesh.vert.cell[:, edge] - 1
+
+        clen = mesh.edge.clen[eidx]
+
+        c1st = mesh.edge.cell[eidx, 0] - 1
+
+        okay = cidx != c1st
+        flip = cidx == c1st
+
+        ivec = np.hstack((
+            ivec, +vidx[flip], vidx[okay]))
+        jvec = np.hstack((
+            jvec, +eidx[flip], eidx[okay]))
+        xvec = np.hstack((
+            xvec, -clen[flip], clen[okay]))
+        
+    return csr_matrix((xvec, (ivec, jvec)))
 
 
 def dual_curl_sums(mesh):
@@ -615,41 +669,6 @@ def dual_edge_sums(mesh):
     return csr_matrix((xvec, (ivec, jvec)))
 
 
-def dual_del2_sums(mesh):
-
-    xvec = np.array([], dtype=np.float64)
-    ivec = np.array([], dtype=np.int32)
-    jvec = np.array([], dtype=np.int32)
-
-    for edge in range(3):
-
-        vidx = np.arange(0, mesh.vert.size)
-
-        eidx = mesh.vert.edge[:, edge] - 1
-
-        aidx = mesh.edge.vert[eidx, 0] - 1
-        bidx = mesh.edge.vert[eidx, 1] - 1
-
-        same = aidx != vidx
-        next = aidx == vidx
-
-        vals = mesh.edge.clen[eidx] / \
-               mesh.edge.vlen[eidx]
-
-        ivec = np.hstack((ivec, +vidx))
-        jvec = np.hstack((jvec, +vidx))
-        xvec = np.hstack((xvec, -vals))
-
-        ivec = np.hstack((
-            ivec, vidx[same], vidx[next]))
-        jvec = np.hstack((
-            jvec, aidx[same], bidx[next]))
-        xvec = np.hstack((
-            xvec, vals[same], vals[next]))
-
-    return csr_matrix((xvec, (ivec, jvec)))
-
-
 def dual_lsqr_fxyz(mesh):
 
     RSPH = mesh.rsph
@@ -682,46 +701,43 @@ def dual_lsqr_fxyz(mesh):
     pdir = pdir / plen
 
     dnrm = np.vstack((
-        mesh.vert.xpos, 
-        mesh.vert.ypos, mesh.vert.zpos)).T
+        mesh.vert.xmid, 
+        mesh.vert.ymid, mesh.vert.zmid)).T
     
     dnrm = dnrm / RSPH
     
-    Tmat = np.zeros(
+    Amat = np.zeros(
         (4, 3, mesh.vert.size), dtype=np.float64)
-    Tmat[0, :, :] = \
+    Amat[0, :, :] = \
         ndir[mesh.vert.edge[:, 0] - 1].T
-    Tmat[1, :, :] = \
+    Amat[1, :, :] = \
         ndir[mesh.vert.edge[:, 1] - 1].T
-    Tmat[2, :, :] = \
+    Amat[2, :, :] = \
         ndir[mesh.vert.edge[:, 2] - 1].T
-    Tmat[3, :, :] = np.transpose(dnrm)
+    Amat[3, :, :] = np.transpose(dnrm)
 
-    Umat = np.zeros(
+    Bmat = np.zeros(
         (4, 3, mesh.vert.size), dtype=np.float64)
-    Umat[0, :, :] = \
+    Bmat[0, :, :] = \
         pdir[mesh.vert.edge[:, 0] - 1].T
-    Umat[1, :, :] = \
+    Bmat[1, :, :] = \
         pdir[mesh.vert.edge[:, 1] - 1].T
-    Umat[2, :, :] = \
+    Bmat[2, :, :] = \
         pdir[mesh.vert.edge[:, 2] - 1].T
-    Umat[3, :, :] = np.transpose(dnrm)
+    Bmat[3, :, :] = np.transpose(dnrm)
 
-    matT = np.transpose(Tmat, axes=(1, 0, 2))
-    matU = np.transpose(Umat, axes=(1, 0, 2))
+    matA = np.transpose(Amat, axes=(1, 0, 2))
+    matB = np.transpose(Bmat, axes=(1, 0, 2))
 
     Rmat = np.einsum(
-        "ik..., kj... -> ij...", matT, Tmat)
+        "ik..., kj... -> ij...", matA, Amat)
 
     Rinv, Rdet = inv_3x3(Rmat)
 
     Smat = np.einsum(
-        "ik..., kj... -> ij...", matU, Umat)
+        "ik..., kj... -> ij...", matB, Bmat)
 
     Sinv, Sdet = inv_3x3(Smat)
-
-    ivec = np.array([], dtype=np.int32)
-    jvec = np.array([], dtype=np.int32)
 
     xnrm = np.array([], dtype=np.float64)
     ynrm = np.array([], dtype=np.float64)
@@ -731,6 +747,9 @@ def dual_lsqr_fxyz(mesh):
     yprp = np.array([], dtype=np.float64)
     zprp = np.array([], dtype=np.float64)
     
+    ivec = np.array([], dtype=np.int32)
+    jvec = np.array([], dtype=np.int32)
+
     for edge in range(3):
 
         vidx = np.arange(0, mesh.vert.size)
@@ -741,21 +760,21 @@ def dual_lsqr_fxyz(mesh):
         jvec = np.hstack((jvec, eidx))
 
         xmul = (
-            Rinv[0, 0, :] * matT[0, edge, :] +
-            Rinv[0, 1, :] * matT[1, edge, :] +
-            Rinv[0, 2, :] * matT[2, edge, :]
+            Rinv[0, 0, :] * matA[0, edge, :] +
+            Rinv[0, 1, :] * matA[1, edge, :] +
+            Rinv[0, 2, :] * matA[2, edge, :]
         ) / Rdet
 
         ymul = (
-            Rinv[1, 0, :] * matT[0, edge, :] +
-            Rinv[1, 1, :] * matT[1, edge, :] +
-            Rinv[1, 2, :] * matT[2, edge, :]
+            Rinv[1, 0, :] * matA[0, edge, :] +
+            Rinv[1, 1, :] * matA[1, edge, :] +
+            Rinv[1, 2, :] * matA[2, edge, :]
         ) / Rdet
 
         zmul = (
-            Rinv[2, 0, :] * matT[0, edge, :] +
-            Rinv[2, 1, :] * matT[1, edge, :] +
-            Rinv[2, 2, :] * matT[2, edge, :]
+            Rinv[2, 0, :] * matA[0, edge, :] +
+            Rinv[2, 1, :] * matA[1, edge, :] +
+            Rinv[2, 2, :] * matA[2, edge, :]
         ) / Rdet
 
         xnrm = np.hstack((xnrm, xmul))
@@ -763,21 +782,21 @@ def dual_lsqr_fxyz(mesh):
         znrm = np.hstack((znrm, zmul))
 
         xmul = (
-            Sinv[0, 0, :] * matU[0, edge, :] +
-            Sinv[0, 1, :] * matU[1, edge, :] +
-            Sinv[0, 2, :] * matU[2, edge, :]
+            Sinv[0, 0, :] * matB[0, edge, :] +
+            Sinv[0, 1, :] * matB[1, edge, :] +
+            Sinv[0, 2, :] * matB[2, edge, :]
         ) / Sdet
 
         ymul = (
-            Sinv[1, 0, :] * matU[0, edge, :] +
-            Sinv[1, 1, :] * matU[1, edge, :] +
-            Sinv[1, 2, :] * matU[2, edge, :]
+            Sinv[1, 0, :] * matB[0, edge, :] +
+            Sinv[1, 1, :] * matB[1, edge, :] +
+            Sinv[1, 2, :] * matB[2, edge, :]
         ) / Sdet
 
         zmul = (
-            Sinv[2, 0, :] * matU[0, edge, :] +
-            Sinv[2, 1, :] * matU[1, edge, :] +
-            Sinv[2, 2, :] * matU[2, edge, :]
+            Sinv[2, 0, :] * matB[0, edge, :] +
+            Sinv[2, 1, :] * matB[1, edge, :] +
+            Sinv[2, 2, :] * matB[2, edge, :]
         ) / Sdet
 
         xprp = np.hstack((xprp, xmul))
@@ -795,8 +814,8 @@ def dual_lsqr_fxyz(mesh):
 def cell_lsqr_fxyz(mesh):
 
     cnrm = np.vstack((
-        mesh.cell.xpos,
-        mesh.cell.ypos, mesh.cell.zpos)).T
+        mesh.cell.xmid,
+        mesh.cell.ymid, mesh.cell.zmid)).T
     
     cnrm = cnrm / mesh.rsph
 
@@ -894,143 +913,9 @@ def cell_lsqr_fxyz(mesh):
            csr_matrix((yvec, (ivec, jvec))), \
            csr_matrix((zvec, (ivec, jvec)))
 
-"""
-def edge_lsqr_fxyz(mesh):
-#-- edge reconstruction via "small" tria-based stencil
-
-    enrm = np.vstack((
-        mesh.edge.xpos,
-        mesh.edge.ypos, mesh.edge.zpos)).T
-    
-    enrm = enrm / mesh.rsph
-
-    edir = np.vstack((
-        mesh.cell.xpos[mesh.edge.cell[:, 1] - 1] -
-        mesh.cell.xpos[mesh.edge.cell[:, 0] - 1],
-        mesh.cell.ypos[mesh.edge.cell[:, 1] - 1] -
-        mesh.cell.ypos[mesh.edge.cell[:, 0] - 1],
-        mesh.cell.zpos[mesh.edge.cell[:, 1] - 1] -
-        mesh.cell.zpos[mesh.edge.cell[:, 0] - 1]))
-    edir = edir.T
-
-    elen = np.sqrt(np.sum(
-        edir ** 2, axis=1, keepdims=True))
-
-    edir = edir / elen
-
-    topo = np.zeros(
-        (mesh.edge.size, 4), dtype=np.int32)
-
-    next = np.zeros(
-        (mesh.edge.size, 1), dtype=np.int32)
-
-    Tmat = np.zeros(
-        (5, 3, mesh.edge.size), dtype=np.float64)
-
-    Wmat = np.zeros(
-        (5, 5, mesh.edge.size), dtype=np.float64)
-
-    for edge in range(3):
-
-        ivrt = mesh.edge.vert[:, 0] - 1
-        jvrt = mesh.edge.vert[:, 1] - 1
-
-    #-- add non-self edge from ivrt
-        eidx = mesh.vert.edge[ivrt, edge] - 1
-
-        enum = np.arange(0, mesh.edge.size)
-
-        keep = eidx != enum
-
-        topo[keep, next[keep, 0]] = eidx[keep]
-        next[keep, 0] += 1
-
-    #-- add non-self edge from jvrt
-        eidx = mesh.vert.edge[jvrt, edge] - 1
-
-        enum = np.arange(0, mesh.edge.size)
-
-        keep = eidx != enum
-
-        topo[keep, next[keep, 0]] = eidx[keep]
-        next[keep, 0] += 1
-
-    for edge in range(5):
-
-        Wmat[edge, edge, :] = +1.0  # unweighted
-
-    for edge in range(4):
-
-        mask = np.full(
-            mesh.edge.size, True, dtype=bool)
-
-        eidx = topo[mask, edge] - 0
-
-        area = mesh.edge.area[eidx].T
-
-        Wmat[edge, edge, mask] = +1.0  # unweighted
-
-        Tmat[edge,    :, mask] = edir[eidx]
-    
-    Tmat[-1, :, :] = np.transpose(enrm)
-    
-
-    matT = np.transpose(Tmat, axes=(1, 0, 2))
-
-    matW = np.einsum(
-        "ik..., kj... -> ij...", matT, Wmat)
-
-    Rmat = np.einsum(
-        "ik..., kj... -> ij...", matW, Tmat)
-
-    Rinv, Rdet = inv_3x3(Rmat)
-
-    xvec = np.array([], dtype=np.float64)
-    yvec = np.array([], dtype=np.float64)
-    zvec = np.array([], dtype=np.float64)
-    ivec = np.array([], dtype=np.int32)
-    jvec = np.array([], dtype=np.int32)
-
-    for edge in range(4):
-
-        mask = np.full(
-            mesh.edge.size, True, dtype=bool)
-
-        enum = np.argwhere(mask).ravel()
-
-        eidx = topo[mask, edge] - 0
-
-        M = mask
-        xmul = (
-            Rinv[0, 0, M] * matW[0, edge, M] +
-            Rinv[0, 1, M] * matW[1, edge, M] +
-            Rinv[0, 2, M] * matW[2, edge, M]
-        ) / Rdet[M]
-
-        ymul = (
-            Rinv[1, 0, M] * matW[0, edge, M] +
-            Rinv[1, 1, M] * matW[1, edge, M] +
-            Rinv[1, 2, M] * matW[2, edge, M]
-        ) / Rdet[M]
-
-        zmul = (
-            Rinv[2, 0, M] * matW[0, edge, M] +
-            Rinv[2, 1, M] * matW[1, edge, M] +
-            Rinv[2, 2, M] * matW[2, edge, M]
-        ) / Rdet[M]
-
-        ivec = np.hstack((ivec, enum))
-        jvec = np.hstack((jvec, eidx))
-        xvec = np.hstack((xvec, xmul))
-        yvec = np.hstack((yvec, ymul))
-        zvec = np.hstack((zvec, zmul))
-
-    return csr_matrix((xvec, (ivec, jvec))), \
-           csr_matrix((yvec, (ivec, jvec))), \
-           csr_matrix((zvec, (ivec, jvec)))
-"""
 
 def edge_lsqr_fxyz(mesh):
+
 #-- edge reconstruction via "large" cell-based stencil
 
     enrm = np.vstack((
@@ -1039,21 +924,38 @@ def edge_lsqr_fxyz(mesh):
     
     enrm = enrm / mesh.rsph
 
-    edir = np.vstack((
+    ndir = np.vstack((
         mesh.cell.xpos[mesh.edge.cell[:, 1] - 1] -
         mesh.cell.xpos[mesh.edge.cell[:, 0] - 1],
         mesh.cell.ypos[mesh.edge.cell[:, 1] - 1] -
         mesh.cell.ypos[mesh.edge.cell[:, 0] - 1],
         mesh.cell.zpos[mesh.edge.cell[:, 1] - 1] -
         mesh.cell.zpos[mesh.edge.cell[:, 0] - 1]))
-    edir = edir.T
+    ndir = ndir.T
 
-    elen = np.sqrt(np.sum(
-        edir ** 2, axis=1, keepdims=True))
+    nlen = np.sqrt(np.sum(
+        ndir ** 2, axis=1, keepdims=True))
 
-    edir = edir / elen
+    pdir = np.vstack((
+        mesh.vert.xpos[mesh.edge.vert[:, 1] - 1] -
+        mesh.vert.xpos[mesh.edge.vert[:, 0] - 1],
+        mesh.vert.ypos[mesh.edge.vert[:, 1] - 1] -
+        mesh.vert.ypos[mesh.edge.vert[:, 0] - 1],
+        mesh.vert.zpos[mesh.edge.vert[:, 1] - 1] -
+        mesh.vert.zpos[mesh.edge.vert[:, 0] - 1]))
+    pdir = pdir.T
 
-    Tmat = np.zeros(
+    plen = np.sqrt(np.sum(
+        pdir ** 2, axis=1, keepdims=True))
+
+    ndir = ndir / nlen
+    pdir = pdir / plen
+
+    Amat = np.zeros(
+        (np.max(mesh.edge.topo) + 1, 3,
+         mesh.edge.size), dtype=np.float64)
+
+    Bmat = np.zeros(
         (np.max(mesh.edge.topo) + 1, 3,
          mesh.edge.size), dtype=np.float64)
 
@@ -1076,24 +978,36 @@ def edge_lsqr_fxyz(mesh):
 
         Wmat[edge, edge, mask] = area
 
-        Tmat[edge,    :, mask] = edir[eidx]
+        Amat[edge,    :, mask] = ndir[eidx]
+        Bmat[edge,    :, mask] = pdir[eidx]
     
-    Tmat[-1, :, :] = np.transpose(enrm)
+    Amat[-1, :, :] = np.transpose(enrm)
+    Bmat[-1, :, :] = np.transpose(enrm)
     
+    matA = np.transpose(Amat, axes=(1, 0, 2))
+    matB = np.transpose(Bmat, axes=(1, 0, 2))
 
-    matT = np.transpose(Tmat, axes=(1, 0, 2))
-
-    matW = np.einsum(
-        "ik..., kj... -> ij...", matT, Wmat)
-
+    matI = np.einsum(
+        "ik..., kj... -> ij...", matA, Wmat)
     Rmat = np.einsum(
-        "ik..., kj... -> ij...", matW, Tmat)
+        "ik..., kj... -> ij...", matI, Amat)
+
+    matJ = np.einsum(
+        "ik..., kj... -> ij...", matB, Wmat)
+    Smat = np.einsum(
+        "ik..., kj... -> ij...", matJ, Bmat)
 
     Rinv, Rdet = inv_3x3(Rmat)
+    Sinv, Sdet = inv_3x3(Smat)
 
-    xvec = np.array([], dtype=np.float64)
-    yvec = np.array([], dtype=np.float64)
-    zvec = np.array([], dtype=np.float64)
+    xnrm = np.array([], dtype=np.float64)
+    ynrm = np.array([], dtype=np.float64)
+    znrm = np.array([], dtype=np.float64)
+
+    xprp = np.array([], dtype=np.float64)
+    yprp = np.array([], dtype=np.float64)
+    zprp = np.array([], dtype=np.float64)
+    
     ivec = np.array([], dtype=np.int32)
     jvec = np.array([], dtype=np.int32)
 
@@ -1105,31 +1019,138 @@ def edge_lsqr_fxyz(mesh):
 
         eidx = mesh.edge.edge[mask, edge] - 1
 
+        ivec = np.hstack((ivec, enum))
+        jvec = np.hstack((jvec, eidx))
+
         M = mask
         xmul = (
-            Rinv[0, 0, M] * matW[0, edge, M] +
-            Rinv[0, 1, M] * matW[1, edge, M] +
-            Rinv[0, 2, M] * matW[2, edge, M]
+            Rinv[0, 0, M] * matI[0, edge, M] +
+            Rinv[0, 1, M] * matI[1, edge, M] +
+            Rinv[0, 2, M] * matI[2, edge, M]
         ) / Rdet[M]
 
         ymul = (
-            Rinv[1, 0, M] * matW[0, edge, M] +
-            Rinv[1, 1, M] * matW[1, edge, M] +
-            Rinv[1, 2, M] * matW[2, edge, M]
+            Rinv[1, 0, M] * matI[0, edge, M] +
+            Rinv[1, 1, M] * matI[1, edge, M] +
+            Rinv[1, 2, M] * matI[2, edge, M]
         ) / Rdet[M]
 
         zmul = (
-            Rinv[2, 0, M] * matW[0, edge, M] +
-            Rinv[2, 1, M] * matW[1, edge, M] +
-            Rinv[2, 2, M] * matW[2, edge, M]
+            Rinv[2, 0, M] * matI[0, edge, M] +
+            Rinv[2, 1, M] * matI[1, edge, M] +
+            Rinv[2, 2, M] * matI[2, edge, M]
         ) / Rdet[M]
 
-        ivec = np.hstack((ivec, enum))
-        jvec = np.hstack((jvec, eidx))
-        xvec = np.hstack((xvec, xmul))
-        yvec = np.hstack((yvec, ymul))
-        zvec = np.hstack((zvec, zmul))
+        xnrm = np.hstack((xnrm, xmul))
+        ynrm = np.hstack((ynrm, ymul))
+        znrm = np.hstack((znrm, zmul))
 
-    return csr_matrix((xvec, (ivec, jvec))), \
-           csr_matrix((yvec, (ivec, jvec))), \
-           csr_matrix((zvec, (ivec, jvec)))
+        M = mask
+        xmul = (
+            Sinv[0, 0, M] * matJ[0, edge, M] +
+            Sinv[0, 1, M] * matJ[1, edge, M] +
+            Sinv[0, 2, M] * matJ[2, edge, M]
+        ) / Sdet[M]
+
+        ymul = (
+            Sinv[1, 0, M] * matJ[0, edge, M] +
+            Sinv[1, 1, M] * matJ[1, edge, M] +
+            Sinv[1, 2, M] * matJ[2, edge, M]
+        ) / Sdet[M]
+
+        zmul = (
+            Sinv[2, 0, M] * matJ[0, edge, M] +
+            Sinv[2, 1, M] * matJ[1, edge, M] +
+            Sinv[2, 2, M] * matJ[2, edge, M]
+        ) / Sdet[M]
+
+        xprp = np.hstack((xprp, xmul))
+        yprp = np.hstack((yprp, ymul))
+        zprp = np.hstack((zprp, zmul))
+
+    return csr_matrix((xnrm, (ivec, jvec))), \
+           csr_matrix((ynrm, (ivec, jvec))), \
+           csr_matrix((znrm, (ivec, jvec))), \
+           csr_matrix((xprp, (ivec, jvec))), \
+           csr_matrix((yprp, (ivec, jvec))), \
+           csr_matrix((zprp, (ivec, jvec)))
+
+
+def edge_dual_reco(mesh, trsk):
+
+#-- EDGE-DUAL-RECO: returns .5 * (xe - xv) * grad(F) part of
+#-- edge reconstruction operator,
+#-- with gradients estimated using "2-ring" stencil on duals.
+
+    vrt1 = mesh.edge.vert[:, 0] - 1
+    xev1 = mesh.edge.xpos - mesh.vert.xmid[vrt1]
+    yev1 = mesh.edge.ypos - mesh.vert.ymid[vrt1]
+    zev1 = mesh.edge.zpos - mesh.vert.zmid[vrt1]
+
+    vrt2 = mesh.edge.vert[:, 1] - 1
+    xev2 = mesh.edge.xpos - mesh.vert.xmid[vrt2]
+    yev2 = mesh.edge.ypos - mesh.vert.ymid[vrt2]
+    zev2 = mesh.edge.zpos - mesh.vert.zmid[vrt2]
+
+    eidx = np.arange(0, mesh.edge.size)
+
+    ivec = np.hstack((eidx, eidx))
+    jvec = np.hstack((vrt1, vrt2))
+
+    xmat = csr_matrix((
+        np.hstack((xev1, xev2)), (ivec, jvec)))
+    
+    ymat = csr_matrix((
+        np.hstack((yev1, yev2)), (ivec, jvec)))
+    
+    zmat = csr_matrix((
+        np.hstack((zev1, zev2)), (ivec, jvec)))
+
+    return (
+        +0.500 * xmat * (trsk.dual_lsqr_xprp * 
+                         trsk.edge_grad_perp) +
+        +0.500 * ymat * (trsk.dual_lsqr_yprp * 
+                         trsk.edge_grad_perp) +
+        +0.500 * zmat * (trsk.dual_lsqr_zprp * 
+                         trsk.edge_grad_perp)
+    )
+
+
+def edge_cell_reco(mesh, trsk):
+
+#-- EDGE-CELL-RECO: returns .5 * (xe - xc) * grad(F) part of
+#-- edge reconstruction operator,
+#-- with gradients estimated using "2-ring" stencil on cells.
+
+    cel1 = mesh.edge.cell[:, 0] - 1
+    xec1 = mesh.edge.xpos - mesh.cell.xmid[cel1]
+    yec1 = mesh.edge.ypos - mesh.cell.ymid[cel1]
+    zec1 = mesh.edge.zpos - mesh.cell.zmid[cel1]
+
+    cel2 = mesh.edge.cell[:, 1] - 1
+    xec2 = mesh.edge.xpos - mesh.cell.xmid[cel2]
+    yec2 = mesh.edge.ypos - mesh.cell.ymid[cel2]
+    zec2 = mesh.edge.zpos - mesh.cell.zmid[cel2]
+
+    eidx = np.arange(0, mesh.edge.size)
+
+    ivec = np.hstack((eidx, eidx))
+    jvec = np.hstack((cel1, cel2))
+
+    xmat = csr_matrix((
+        np.hstack((xec1, xec2)), (ivec, jvec)))
+    
+    ymat = csr_matrix((
+        np.hstack((yec1, yec2)), (ivec, jvec)))
+    
+    zmat = csr_matrix((
+        np.hstack((zec1, zec2)), (ivec, jvec)))
+
+    return (
+        +0.500 * xmat * (trsk.cell_lsqr_xnrm * 
+                         trsk.edge_grad_norm) +
+        +0.500 * ymat * (trsk.cell_lsqr_ynrm * 
+                         trsk.edge_grad_norm) +
+        +0.500 * zmat * (trsk.cell_lsqr_znrm * 
+                         trsk.edge_grad_norm)
+    )

--- a/ops.py
+++ b/ops.py
@@ -1,4 +1,5 @@
 
+import warnings
 import numpy as np
 from scipy.sparse import csr_matrix, spdiags
 from mat import inv_3x3
@@ -108,8 +109,11 @@ def trsk_mats(mesh):
     # take curl on rhombi, a'la Gassmann
     trsk.quad_curl_sums = trsk.edge_vert_sums \
                         * trsk.dual_curl_sums
-    trsk.quad_curl_sums.setdiag(0.0)
-    trsk.quad_curl_sums.eliminate_zeros()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        trsk.quad_curl_sums.setdiag(0.)
+        trsk.quad_curl_sums.eliminate_zeros()
 
     # least-squares vector reconstruction operators
     trsk.dual_lsqr_xnrm, \

--- a/swe.py
+++ b/swe.py
@@ -8,20 +8,11 @@ import argparse
 from msh import load_mesh, load_flow
 from ops import trsk_mats
 
-
-HH_TINY        = 1.0E-02
-UU_TINY        = 1.0E-16
-
-class base: pass
-tcpu = base()
-tcpu.thickness = 0.0E+00
-tcpu.momentum_ = 0.0E+00
-tcpu.upwinding = 0.0E+00
-tcpu.compute_H = 0.0E+00
-tcpu.computeKE = 0.0E+00
-tcpu.computePV = 0.0E+00
-tcpu.advect_PV = 0.0E+00
-tcpu.computeDU = 0.0E+00
+from _dx import HH_TINY, UU_TINY
+from _dx import invariant, tcpu
+from _dt import step_RK22, step_SE22, \
+                step_RK32, step_SE32, \
+                step_SP33#,step_RK44
 
 def swe(cnfg):
     """
@@ -45,9 +36,13 @@ def swe(cnfg):
     path, file = os.path.split(name)
     save = os.path.join(path, "out_" + file)
 
+    print("Loading input assets...")
+    
     # load mesh + init. conditions
     mesh = load_mesh(name, sort=True)
     flow = load_flow(name, mesh=mesh)
+
+    print("Creating output file...")
 
     init_file(name, cnfg, save)
 
@@ -57,6 +52,8 @@ def swe(cnfg):
     hh_cell = h0_cell
 
     hh_cell = np.maximum(HH_TINY, hh_cell)
+
+    print("Forming coefficients...")
 
     # set sparse spatial operators
     trsk = trsk_mats(mesh)
@@ -75,17 +72,11 @@ def swe(cnfg):
     pv_sums = np.zeros((
         cnfg.iteration // cnfg.stat_freq + 1), dtype=np.float64)
 
+    print("Integrating:")
+
     ttic = time.time(); xout = []; next = 0; freq = 0
 
     for step in range(cnfg.iteration + 1):
-
-        if ("RK11" in cnfg.integrate):
-
-            hh_cell, uu_edge, ke_cell, ke_dual, \
-            rv_cell, pv_cell, \
-            rv_dual, pv_dual, \
-            ke_bias, pv_bias = step_RK11(
-                mesh, trsk, flow, cnfg, hh_cell, uu_edge)
 
         if ("RK22" in cnfg.integrate):
 
@@ -95,12 +86,28 @@ def swe(cnfg):
             ke_bias, pv_bias = step_RK22(
                 mesh, trsk, flow, cnfg, hh_cell, uu_edge)
 
+        if ("SE22" in cnfg.integrate):
+
+            hh_cell, uu_edge, ke_cell, ke_dual, \
+            rv_cell, pv_cell, \
+            rv_dual, pv_dual, \
+            ke_bias, pv_bias = step_SE22(
+                mesh, trsk, flow, cnfg, hh_cell, uu_edge)
+
         if ("RK32" in cnfg.integrate):
 
             hh_cell, uu_edge, ke_cell, ke_dual, \
             rv_cell, pv_cell, \
             rv_dual, pv_dual, \
             ke_bias, pv_bias = step_RK32(
+                mesh, trsk, flow, cnfg, hh_cell, uu_edge)
+
+        if ("SE32" in cnfg.integrate):
+
+            hh_cell, uu_edge, ke_cell, ke_dual, \
+            rv_cell, pv_cell, \
+            rv_dual, pv_dual, \
+            ke_bias, pv_bias = step_SE32(
                 mesh, trsk, flow, cnfg, hh_cell, uu_edge)
 
         if ("SP33" in cnfg.integrate):
@@ -203,7 +210,7 @@ def swe(cnfg):
 
     ttoc = time.time()
 
-    print("TCPU:", ttoc - ttic)
+    print("Total run time:", ttoc - ttic)
     print("tcpu.thickness:", tcpu.thickness)
     print("tcpu.momentum_:", tcpu.momentum_)
     print("tcpu.upwinding:", tcpu.upwinding) 
@@ -370,1043 +377,6 @@ def init_file(name, cnfg, save):
     data.close()
 
 
-def invariant(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
-
-    ff_dual = flow.ff_vert
-    ff_edge = flow.ff_edge
-    ff_cell = flow.ff_cell
-
-    zb_cell = flow.zb_cell
-
-    vv_edge = trsk.edge_lsqr_perp * uu_edge * +1.
-
-    hh_dual, \
-    hh_edge = compute_H(mesh, trsk, cnfg, hh_cell, uu_edge)
-
-    ke_edge =  0.5 * uu_edge ** 2
-
-    ke_edge = ke_edge * hh_edge * mesh.edge.clen \
-                                * mesh.edge.vlen
-
-    pe_cell = flow.grav * (hh_cell * 0.5 + zb_cell)
-
-    pe_cell = pe_cell * hh_cell * mesh.cell.area
-
-    kk_sums = np.sum(ke_edge) + np.sum(pe_cell)
-
-    rv_dual, pv_dual, rv_cell, pv_cell, \
-    pv_edge, __ = computePV(
-        mesh, trsk, cnfg, 
-        hh_cell, hh_edge, hh_dual, uu_edge, vv_edge,
-        ff_dual, ff_edge, ff_cell, 
-        +0.0 * cnfg.time_step, 0.0 * cnfg.pv_upwind)
-
-   #pv_sums = np.sum(
-   #    +0.5 * mesh.edge.area * hh_edge * pv_edge ** 2)
-
-    pv_sums = np.sum(
-        +0.5 * mesh.vert.area * hh_dual * pv_dual ** 2)
-
-    return kk_sums, pv_sums
-
-
-def step_RK11(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
-
-#-- standard FB.-RK(1,1) method
-
-    ff_cell = flow.ff_cell
-    ff_edge = flow.ff_edge
-    ff_dual = flow.ff_vert
-
-    zb_cell = flow.zb_cell
-
-#-- 1st RK + FB stage
-
-    ttic = time.time()
-
-    BETA = (1.0 / 1.0) * ("FB" in cnfg.integrate)
-
-    vv_edge = trsk.edge_lsqr_perp * uu_edge
-
-    hh_dual, \
-    hh_edge = compute_H(mesh, trsk, cnfg, hh_cell, uu_edge)
-
-    uh_edge = uu_edge * hh_edge
-
-    uh_cell = trsk.cell_flux_sums * uh_edge
-    uh_cell/= mesh.cell.area
-
-    h1_cell = (
-        hh_cell - 1.0 / 1.0 * cnfg.time_step * uh_cell
-    )
-
-    ttoc = time.time()
-    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
-
-    ttic = time.time()
-
-    hb_cell = h1_cell * (0.0 + 1.0 * BETA) + \
-              hh_cell * (1.0 - 1.0 * BETA)
-
-    hb_dual, \
-    hb_edge = compute_H(mesh, trsk, cnfg, hb_cell, uu_edge)
-
-    uh_edge = uu_edge * hb_edge
-
-    ke_dual, ke_cell, ke_bias = computeKE(
-        mesh, trsk, cnfg, 
-        hb_cell, hb_edge, hb_dual, 
-        uu_edge, vv_edge,
-        +0.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
-
-    hk_cell = hb_cell + zb_cell 
-    hk_cell = ke_cell + hk_cell * flow.grav
-
-    hk_grad = trsk.edge_grad_norm * hk_cell
-
-    rv_dual, pv_dual, rv_cell, pv_cell, \
-    pv_edge, pv_bias = computePV(
-        mesh, trsk, cnfg, 
-        hb_cell, hb_edge, hb_dual, uu_edge, vv_edge, 
-        ff_dual, ff_edge, ff_cell, 
-        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
-
-    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
-
-    uu_damp = computeDU(mesh, trsk, cnfg, uu_edge)
-
-    u1_edge = uu_edge - 1.0 / 1.0 * cnfg.time_step * (
-        hk_grad + qh_flux - uu_damp
-    )
-
-    ttoc = time.time()
-    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
-
-    return h1_cell, u1_edge, ke_cell, ke_dual, \
-           rv_cell, pv_cell, \
-           rv_dual, pv_dual, ke_bias, pv_bias
-
-
-def step_RK22(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
-
-#-- A 2-stage RK2 + FB scheme, a'la ROMS:
-#-- A.F. Shchepetkin, J.C. McWilliams (2005): The regional oceanic 
-#-- modeling system (ROMS): a split-explicit, free-surface, 
-#-- topography-following-coordinate oceanic model
-#-- doi.org/10.1016/j.ocemod.2004.08.002
-
-#-- but with thickness updated via an SSP-RK2 approach
-
-    ff_cell = flow.ff_cell
-    ff_edge = flow.ff_edge
-    ff_dual = flow.ff_vert
-
-    zb_cell = flow.zb_cell
-
-#-- 1st RK + FB stage
-
-    ttic = time.time()
-
-    BETA = (1.0 / 3.0) * ("FB" in cnfg.integrate)
-
-    vv_edge = trsk.edge_lsqr_perp * uu_edge
-
-    hh_dual, \
-    hh_edge = compute_H(mesh, trsk, cnfg, hh_cell, uu_edge)
-
-    uh_edge = uu_edge * hh_edge
-
-    uh_cell = trsk.cell_flux_sums * uh_edge
-    uh_cell/= mesh.cell.area
-
-    h1_cell = (
-        hh_cell - 1.0 / 1.0 * cnfg.time_step * uh_cell
-    )
-
-    ttoc = time.time()
-    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
-
-    ttic = time.time()
-
-    hb_cell = h1_cell * (0.0 + 1.0 * BETA) + \
-              hh_cell * (1.0 - 1.0 * BETA)
-
-    hb_dual, \
-    hb_edge = compute_H(mesh, trsk, cnfg, hb_cell, uu_edge)
-
-    uh_edge = uu_edge * hb_edge
-
-    ke_dual, ke_cell, __ = computeKE(
-        mesh, trsk, cnfg, 
-        hb_cell, hb_edge, hb_dual, 
-        uu_edge, vv_edge,
-        +1.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
-
-    hk_cell = hb_cell + zb_cell 
-    hk_cell = ke_cell + hk_cell * flow.grav
-
-    hk_grad = trsk.edge_grad_norm * hk_cell
-
-    rv_dual, pv_dual, rv_cell, pv_cell, \
-    pv_edge, __ = computePV(
-        mesh, trsk, cnfg, 
-        hb_cell, hb_edge, hb_dual, uu_edge, vv_edge, 
-        ff_dual, ff_edge, ff_cell, 
-        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
-
-    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
-
-    uu_damp = computeDU(mesh, trsk, cnfg, uu_edge)
-
-    u1_edge = uu_edge - 1.0 / 1.0 * cnfg.time_step * (
-        hk_grad + qh_flux - uu_damp
-    )
-
-    ttoc = time.time()
-    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
-
-#-- 2nd RK + FB stage
-
-    ttic = time.time()
-
-    BETA = (2.0 / 3.0) * ("FB" in cnfg.integrate)
-
-    hm_cell = 0.5 * hh_cell + 0.5 * h1_cell
-    um_edge = 0.5 * uu_edge + 0.5 * u1_edge
-
-    vm_edge = trsk.edge_lsqr_perp * um_edge
-
-    h1_dual, \
-    h1_edge = compute_H(mesh, trsk, cnfg, h1_cell, u1_edge)
-
-    uh_edge = u1_edge * h1_edge
-
-    uh_cell = trsk.cell_flux_sums * uh_edge
-    uh_cell/= mesh.cell.area
-
-    h2_cell = (
-        hm_cell - 1.0 / 2.0 * cnfg.time_step * uh_cell
-    )
-
-    ttoc = time.time()
-    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
-
-    ttic = time.time()
-
-    hb_cell = h2_cell * (0.0 + 0.5 * BETA) + \
-              h1_cell * (0.5 - 0.5 * BETA) + \
-              hh_cell * (0.5)
-
-    hb_dual, \
-    hb_edge = compute_H(mesh, trsk, cnfg, hb_cell, um_edge)
-
-    uh_edge = um_edge * hb_edge
-
-    ke_dual, ke_cell, ke_bias = computeKE(
-        mesh, trsk, cnfg, 
-        hb_cell, hb_edge, hb_dual, 
-        um_edge, vm_edge,
-        +1.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
-
-    hk_cell = hb_cell + zb_cell 
-    hk_cell = ke_cell + hk_cell * flow.grav
-
-    hk_grad = trsk.edge_grad_norm * hk_cell
-
-    rv_dual, pv_dual, rv_cell, pv_cell, \
-    pv_edge, pv_bias = computePV(
-        mesh, trsk, cnfg, 
-        hb_cell, hb_edge, hb_dual, um_edge, vm_edge,
-        ff_dual, ff_edge, ff_cell, 
-        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
-
-    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
-
-    uu_damp = computeDU(mesh, trsk, cnfg, um_edge)
-
-    u2_edge = uu_edge - 1.0 / 1.0 * cnfg.time_step * (
-        hk_grad + qh_flux - uu_damp
-    )
-
-    ttoc = time.time()
-    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
-
-    return h2_cell, u2_edge, ke_cell, ke_dual, \
-           rv_cell, pv_cell, \
-           rv_dual, pv_dual, ke_bias, pv_bias
-
-
-def step_RK32(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
-
-#-- A 3-stage RK2 + FB scheme, a'la MPAS-A:
-#-- L.J. Wicker, W.C. Skamarock (2002): Time-Splitting Methods for 
-#-- Elastic Models Using Forward Time Schemes
-#-- doi.org/10.1175/1520-0493(2002)130<2088:TSMFEM>2.0.CO;2
-
-#-- but with FB weighting applied within each RK stage
-
-    ff_cell = flow.ff_cell
-    ff_edge = flow.ff_edge
-    ff_dual = flow.ff_vert
-
-    zb_cell = flow.zb_cell
-
-#-- 1st RK + FB stage
-
-    ttic = time.time()
-
-    BETA = (1.0 / 3.0) * ("FB" in cnfg.integrate)
-
-    vv_edge = trsk.edge_lsqr_perp * uu_edge
-
-    hh_dual, \
-    hh_edge = compute_H(mesh, trsk, cnfg, hh_cell, uu_edge)
-
-    uh_edge = uu_edge * hh_edge
-
-    uh_cell = trsk.cell_flux_sums * uh_edge
-    uh_cell/= mesh.cell.area
-
-    h1_cell = (
-        hh_cell - 1.0 / 3.0 * cnfg.time_step * uh_cell
-    )
-
-    ttoc = time.time()
-    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
-
-    ttic = time.time()
-
-    hb_cell = h1_cell * (0.0 + 1.0 * BETA) + \
-              hh_cell * (1.0 - 1.0 * BETA)
-
-    hb_dual, \
-    hb_edge = compute_H(mesh, trsk, cnfg, hb_cell, uu_edge)
-
-    uh_edge = uu_edge * hb_edge
-
-    ke_dual, ke_cell, __ = computeKE(
-        mesh, trsk, cnfg, 
-        hb_cell, hb_edge, hb_dual, 
-        uu_edge, vv_edge,
-        +1.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
-
-    hk_cell = hb_cell + zb_cell 
-    hk_cell = ke_cell + hk_cell * flow.grav
-
-    hk_grad = trsk.edge_grad_norm * hk_cell
-
-    rv_dual, pv_dual, rv_cell, pv_cell, \
-    pv_edge, __ = computePV(
-        mesh, trsk, cnfg, 
-        hb_cell, hb_edge, hb_dual, uu_edge, vv_edge, 
-        ff_dual, ff_edge, ff_cell, 
-        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
-
-    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
-
-    uu_damp = computeDU(mesh, trsk, cnfg, uu_edge)
-
-    u1_edge = uu_edge - 1.0 / 3.0 * cnfg.time_step * (
-        hk_grad + qh_flux - uu_damp
-    )
-
-    ttoc = time.time()
-    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
-
-#-- 2nd RK + FB stage
-
-    ttic = time.time()
-
-    BETA = (1.0 / 2.0) * ("FB" in cnfg.integrate)
-
-    v1_edge = trsk.edge_lsqr_perp * u1_edge
-
-    h1_dual, \
-    h1_edge = compute_H(mesh, trsk, cnfg, h1_cell, u1_edge)
-
-    uh_edge = u1_edge * h1_edge
-
-    uh_cell = trsk.cell_flux_sums * uh_edge
-    uh_cell/= mesh.cell.area
-
-    h2_cell = (
-        hh_cell - 1.0 / 2.0 * cnfg.time_step * uh_cell
-    )
-
-    ttoc = time.time()
-    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
-
-    ttic = time.time()
-
-    # centred at 1/4 for 1/2 step?
-    hb_cell = h2_cell * (0.0 + 1.0 * BETA) + \
-              hh_cell * (1.0 - 1.0 * BETA)
-
-    hb_dual, \
-    hb_edge = compute_H(mesh, trsk, cnfg, hb_cell, u1_edge)
-
-    uh_edge = u1_edge * hb_edge
-
-    ke_dual, ke_cell, __ = computeKE(
-        mesh, trsk, cnfg, 
-        hb_cell, hb_edge, hb_dual, 
-        u1_edge, v1_edge,
-        +1.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
-
-    hk_cell = hb_cell + zb_cell 
-    hk_cell = ke_cell + hk_cell * flow.grav
-
-    hk_grad = trsk.edge_grad_norm * hk_cell
-
-    rv_dual, pv_dual, rv_cell, pv_cell, \
-    pv_edge, __ = computePV(
-        mesh, trsk, cnfg, 
-        hb_cell, hb_edge, hb_dual, u1_edge, v1_edge, 
-        ff_dual, ff_edge, ff_cell, 
-        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
-
-    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
-
-    uu_damp = computeDU(mesh, trsk, cnfg, u1_edge)
-
-    u2_edge = uu_edge - 1.0 / 2.0 * cnfg.time_step * (
-        hk_grad + qh_flux - uu_damp
-    )
-
-    ttoc = time.time()
-    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
-
-#-- 3rd RK + FB stage
-
-    ttic = time.time()
-
-    BETA = (89. / 300) * ("FB" in cnfg.integrate)
-   #BETA = (0.2969771) * ("FB" in cnfg.integrate)
-    
-    v2_edge = trsk.edge_lsqr_perp * u2_edge
-
-    h2_dual, \
-    h2_edge = compute_H(mesh, trsk, cnfg, h2_cell, u2_edge)
-
-    uh_edge = u2_edge * h2_edge
-
-    uh_cell = trsk.cell_flux_sums * uh_edge
-    uh_cell/= mesh.cell.area
-
-    h3_cell = (
-        hh_cell - 1.0 / 1.0 * cnfg.time_step * uh_cell
-    )
-
-    ttoc = time.time()
-    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
-
-    ttic = time.time()
-
-    # centred at 1/2 for 1/1 step?
-    hb_cell = h3_cell * (0.0 + 1.0 * BETA) + \
-              h2_cell * (1.0 - 2.0 * BETA) + \
-              hh_cell * (0.0 + 1.0 * BETA)
-
-    hb_dual, \
-    hb_edge = compute_H(mesh, trsk, cnfg, hb_cell, u2_edge)
-
-    uh_edge = u2_edge * hb_edge
-
-    ke_dual, ke_cell, ke_bias = computeKE(
-        mesh, trsk, cnfg, 
-        hb_cell, hb_edge, hb_dual, 
-        u2_edge, v2_edge,
-        +1.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
-
-    hk_cell = hb_cell + zb_cell 
-    hk_cell = ke_cell + hk_cell * flow.grav
-
-    hk_grad = trsk.edge_grad_norm * hk_cell
-
-    rv_dual, pv_dual, rv_cell, pv_cell, \
-    pv_edge, pv_bias = computePV(
-        mesh, trsk, cnfg, 
-        hb_cell, hb_edge, hb_dual, u2_edge, v2_edge,
-        ff_dual, ff_edge, ff_cell, 
-        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
-
-    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
-
-    uu_damp = computeDU(mesh, trsk, cnfg, u2_edge)
-
-    u3_edge = uu_edge - 1.0 / 1.0 * cnfg.time_step * (
-        hk_grad + qh_flux - uu_damp
-    )
-
-    ttoc = time.time()
-    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
-
-    return h3_cell, u3_edge, ke_cell, ke_dual, \
-           rv_cell, pv_cell, \
-           rv_dual, pv_dual, ke_bias, pv_bias
-
-
-def step_SP33(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
-
-#-- standard SSP-RK(3,3) method
-
-    ff_cell = flow.ff_cell
-    ff_edge = flow.ff_edge
-    ff_dual = flow.ff_vert
-
-    zb_cell = flow.zb_cell
-
-#-- 1st RK + FB stage
-
-    ttic = time.time()
-
-    vv_edge = trsk.edge_lsqr_perp * uu_edge
-
-    hh_dual, \
-    hh_edge = compute_H(mesh, trsk, cnfg, hh_cell, uu_edge)
-
-    uh_edge = uu_edge * hh_edge
-
-    uh_cell = trsk.cell_flux_sums * uh_edge
-    uh_cell/= mesh.cell.area
-
-    h1_cell = (
-        hh_cell - 1.0 / 1.0 * cnfg.time_step * uh_cell
-    )
-
-    ttoc = time.time()
-    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
-
-    ttic = time.time()
-
-    ke_dual, ke_cell, __ = computeKE(
-        mesh, trsk, cnfg, 
-        hh_cell, hh_edge, hh_dual, 
-        uu_edge, vv_edge,
-        +1.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
-
-    hk_cell = hh_cell + zb_cell 
-    hk_cell = ke_cell + hk_cell * flow.grav
-
-    hk_grad = trsk.edge_grad_norm * hk_cell
-
-    rv_dual, pv_dual, rv_cell, pv_cell, \
-    pv_edge, __ = computePV(
-        mesh, trsk, cnfg, 
-        hh_cell, hh_edge, hh_dual, uu_edge, vv_edge, 
-        ff_dual, ff_edge, ff_cell, 
-        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
-
-    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
-
-    uu_damp = computeDU(mesh, trsk, cnfg, uu_edge)
-
-    u1_edge = uu_edge - 1.0 / 1.0 * cnfg.time_step * (
-        hk_grad + qh_flux - uu_damp
-    )
-
-    ttoc = time.time()
-    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
-
-#-- 2nd RK + FB stage
-
-    ttic = time.time()
-
-    v1_edge = trsk.edge_lsqr_perp * u1_edge
-
-    h1_dual, \
-    h1_edge = compute_H(mesh, trsk, cnfg, h1_cell, u1_edge)
-
-    uh_edge = u1_edge * h1_edge
-
-    uh_cell = trsk.cell_flux_sums * uh_edge
-    uh_cell/= mesh.cell.area
-
-    h2_cell = (
-        3.0 / 4.0 * hh_cell + 
-        1.0 / 4.0 * h1_cell - 
-            1.0 / 4.0 * cnfg.time_step * uh_cell
-    )
-
-    ttoc = time.time()
-    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
-
-    ttic = time.time()
-
-    ke_dual, ke_cell, __ = computeKE(
-        mesh, trsk, cnfg, 
-        h1_cell, h1_edge, h1_dual, 
-        u1_edge, v1_edge,
-        +1.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
-
-    hk_cell = h1_cell + zb_cell 
-    hk_cell = ke_cell + hk_cell * flow.grav
-
-    hk_grad = trsk.edge_grad_norm * hk_cell
-
-    rv_dual, pv_dual, rv_cell, pv_cell, \
-    pv_edge, __ = computePV(
-        mesh, trsk, cnfg, 
-        h1_cell, h1_edge, h1_dual, u1_edge, v1_edge, 
-        ff_dual, ff_edge, ff_cell, 
-        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
-
-    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
-
-    uu_damp = computeDU(mesh, trsk, cnfg, u1_edge)
-
-    u2_edge = (
-        3.0 / 4.0 * uu_edge +
-        1.0 / 4.0 * u1_edge - 
-            1.0 / 4.0 * cnfg.time_step * (
-                hk_grad + qh_flux - uu_damp
-    ))
-
-    ttoc = time.time()
-    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
-
-#-- 3rd RK + FB stage
-
-    ttic = time.time()
-
-    v2_edge = trsk.edge_lsqr_perp * u2_edge
-
-    h2_dual, \
-    h2_edge = compute_H(mesh, trsk, cnfg, h2_cell, u2_edge)
-
-    uh_edge = u2_edge * h2_edge
-
-    uh_cell = trsk.cell_flux_sums * uh_edge
-    uh_cell/= mesh.cell.area
-
-    h3_cell = (
-        1.0 / 3.0 * hh_cell +
-        2.0 / 3.0 * h2_cell - 
-            2.0 / 3.0 * cnfg.time_step * uh_cell
-    )
-
-    ttoc = time.time()
-    tcpu.thickness = tcpu.thickness + (ttoc - ttic)
-
-    ttic = time.time()
-
-    ke_dual, ke_cell, ke_bias = computeKE(
-        mesh, trsk, cnfg, 
-        h2_cell, h2_edge, h2_dual, 
-        u2_edge, v2_edge,
-        +1.0 / 2.0 * cnfg.time_step, cnfg.ke_upwind)
-
-    hk_cell = h2_cell + zb_cell 
-    hk_cell = ke_cell + hk_cell * flow.grav
-
-    hk_grad = trsk.edge_grad_norm * hk_cell
-
-    rv_dual, pv_dual, rv_cell, pv_cell, \
-    pv_edge, pv_bias = computePV(
-        mesh, trsk, cnfg, 
-        h2_cell, h2_edge, h2_dual, u2_edge, v2_edge, 
-        ff_dual, ff_edge, ff_cell, 
-        +1.0 / 2.0 * cnfg.time_step, cnfg.pv_upwind)
-
-    qh_flux = advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge)
-
-    uu_damp = computeDU(mesh, trsk, cnfg, u2_edge)
-
-    u3_edge = (
-        1.0 / 3.0 * uu_edge +
-        2.0 / 3.0 * u2_edge - 
-            2.0 / 3.0 * cnfg.time_step * (
-                hk_grad + qh_flux - uu_damp
-    ))
-
-    ttoc = time.time()
-    tcpu.momentum_ = tcpu.momentum_ + (ttoc - ttic)
-
-    return h3_cell, u3_edge, ke_cell, ke_dual, \
-           rv_cell, pv_cell, \
-           rv_dual, pv_dual, ke_bias, pv_bias
-
-
-def hrmn_mean(xone, xtwo):
-
-#-- harmonic mean of two vectors (ie. biased toward lesser)
-
-    return +2.0 * xone * xtwo / (xone + xtwo)
-
-
-def upwinding(mesh, trsk, cnfg, 
-              sv_dual, sm_dual, sv_cell, sv_edge,
-              uu_edge, vv_edge, 
-              delta_t, up_bias):
-
-    ttic = time.time()
-
-    if (cnfg.up_scheme == "LUST"):
-
-    #-- upwind bias, a'la Weller
-    #-- H. Weller (2012): Controlling the computational modes 
-    #-- of the arbitrarily structured C grid
-    #-- https://doi.org/10.1175/MWR-D-11-00221.1
-        dv_edge = trsk.edge_grad_perp * sv_dual
-
-        dx_dual = trsk.dual_lsqr_xprp * dv_edge
-        dy_dual = trsk.dual_lsqr_yprp * dv_edge
-        dz_dual = trsk.dual_lsqr_zprp * dv_edge
-
-        sv_bias = np.zeros(mesh.edge.size)
-
-        up_edge = np.where(vv_edge <= 0.0)
-        dn_edge = np.where(vv_edge >= 0.0)
-
-        up_dual = np.zeros(
-            mesh.edge.size, dtype=np.int32)
-        up_dual[up_edge] = \
-            mesh.edge.vert[up_edge, 1] - 1
-        up_dual[dn_edge] = \
-            mesh.edge.vert[dn_edge, 0] - 1
-
-        up_xdel = \
-            mesh.edge.xpos - mesh.vert.xmid[up_dual]
-        up_ydel = \
-            mesh.edge.ypos - mesh.vert.ymid[up_dual]
-        up_zdel = \
-            mesh.edge.zpos - mesh.vert.zmid[up_dual]
-
-        va_edge = np.abs(vv_edge) + UU_TINY
-        ua_edge = np.abs(uu_edge) + UU_TINY
-        
-        BIAS = (
-            up_bias * va_edge / (ua_edge + va_edge)
-        )
-
-        sv_wind = sv_dual[up_dual] + \
-            up_xdel * dx_dual[up_dual] + \
-            up_ydel * dy_dual[up_dual] + \
-            up_zdel * dz_dual[up_dual]
-
-        sv_edge = \
-            BIAS * sv_wind + (1.0 - BIAS) * sv_edge
-
-    if (cnfg.up_scheme == "APVM"):
-
-        dn_edge = trsk.edge_grad_norm * sv_cell
-        dp_edge = trsk.edge_grad_perp * sv_dual
-
-        sv_bias = np.zeros(mesh.edge.size)
-
-    #-- upwind APVM, scale w time
-        up_bias = 1.0                   # hard-coded?
-        sv_apvm = up_bias * uu_edge * dn_edge + \
-                  up_bias * vv_edge * dp_edge
-
-        sv_edge = sv_edge - delta_t * sv_apvm
-        
-    if (cnfg.up_scheme == "UUST"):
-
-        dn_edge = trsk.edge_grad_norm * sv_cell
-        dp_edge = trsk.edge_grad_perp * sv_dual
-
-        sv_bias = np.zeros(mesh.edge.size)
-
-    #-- upwind APVM, scale w grid
-        um_edge = UU_TINY + \
-            np.sqrt(uu_edge ** 2 + vv_edge ** 2)
-
-        sv_wind = uu_edge * dn_edge / um_edge + \
-                  vv_edge * dp_edge / um_edge
-
-        ee_scal = mesh.edge.slen
-
-        sv_edge-= up_bias * ee_scal * sv_wind
-
-    if (cnfg.up_scheme == "AUST"):
-        
-    #-- AUST: anticipated upstream method; APVM meets
-    #-- LUST? Upwinds in multi-dimensional sense, vs.
-    #-- LUST, which upwinds via tangential dir. only.
-
-        dn_edge = trsk.edge_grad_norm * sv_cell
-        dp_edge = trsk.edge_grad_perp * sv_dual
-
-        dm_edge = 0.5 * (
-            np.abs(dn_edge * mesh.edge.clen) +
-            np.abs(dp_edge * mesh.edge.vlen)
-        )
-
-        ds_dual = np.abs(sv_dual - sm_dual)
-
-        ds_edge = \
-            (trsk.edge_vert_sums * ds_dual) / 2.0
-       
-        sv_bias = ds_edge / (dm_edge + UU_TINY)
-
-    #-- upwind APVM, scale w grid
-        um_edge = UU_TINY + \
-            np.sqrt(uu_edge ** 2 + vv_edge ** 2)
-
-        sv_wind = uu_edge * dn_edge / um_edge + \
-                  vv_edge * dp_edge / um_edge
-
-        ee_scal = mesh.edge.slen
-
-        sv_bias = up_bias \
-            + np.minimum(+1./4. - up_bias, sv_bias)
-
-        sv_edge-= sv_bias * ee_scal * sv_wind
-
-    ttoc = time.time()
-    tcpu.upwinding = tcpu.upwinding + (ttoc - ttic)
-
-    return sv_edge, sv_bias
-
-
-def compute_H(mesh, trsk, cnfg, hh_cell, uu_edge):
-
-    ttic = time.time()
-
-    if (cnfg.operators == "TRSK-CV"):
-
-        hh_dual = trsk.dual_kite_sums * hh_cell
-        hh_dual/= mesh.vert.area
-
-        hh_edge = trsk.edge_wing_sums * hh_cell
-        hh_edge/= mesh.edge.area
-
-    if (cnfg.operators == "TRSK-MD"):
-
-        hh_dual = trsk.dual_kite_sums * hh_cell
-        hh_dual/= mesh.vert.area
-
-        hh_edge = trsk.edge_cell_sums * hh_cell
-        hh_edge*= 0.5E+00
-
-    ttoc = time.time()
-    tcpu.compute_H = tcpu.compute_H + (ttoc - ttic)
-
-    return hh_dual, hh_edge
-
-
-def computePV(mesh, trsk, cnfg, 
-              hh_cell, hh_edge, hh_dual, uu_edge, vv_edge, 
-              ff_dual, ff_edge, ff_cell,
-              delta_t, up_bias):
-
-    ttic = time.time()
-
-    if (cnfg.operators == "TRSK-CV"):
-
-    #-- RV+f on rhombi, PV on edge - more compact stencil?        
-        rv_dual = trsk.dual_curl_sums * uu_edge
-        rv_dual/= mesh.vert.area
-        
-        av_dual = rv_dual + ff_dual
-        pv_dual = av_dual / hh_dual
-        
-        rv_cell = trsk.cell_kite_sums * rv_dual
-        rv_cell/= mesh.cell.area
-
-        av_cell = rv_cell + ff_cell
-        pv_cell = av_cell / hh_cell
-
-    #-- compute curl on rhombi -- a'la Gassmann
-        rm_edge = trsk.quad_curl_sums * uu_edge
-        rm_edge/= mesh.quad.area
-
-        hv_edge = trsk.edge_stub_sums * hh_dual
-        hv_edge/= mesh.edge.area
-
-        hm_edge = 1. / 2. * hh_edge \
-                + 1. / 2. * hv_edge
-        
-        am_edge = rm_edge + ff_edge
-        pm_edge = am_edge / hm_edge
-
-    #-- average rhombi to dual -- a'la Gassmann
-        rm_dual = trsk.dual_edge_sums * rm_edge / 3.0
-
-        am_dual = rm_dual + ff_dual
-        pm_dual = am_dual / hh_dual
-
-    #-- compute high(er)-order RV + PV on edges:
-    #-- pv_edge = pv_dual + (xe - xv) * pv_d/dx
-        pv_edge = trsk.edge_vert_sums * pv_dual / 2.0
-        pv_edge+= trsk.edge_dual_reco * pm_dual
-
-        pv_edge = 3. / 8. * pv_edge \
-                + 5. / 8. * pm_edge
-
-        pv_edge, up_edge = upwinding(
-            mesh, trsk, cnfg, 
-            pv_dual, pm_dual, pv_cell, pv_edge,
-            uu_edge, vv_edge, delta_t, up_bias)
-        
-    if (cnfg.operators == "TRSK-MD"):
-
-        rv_dual = trsk.dual_curl_sums * uu_edge
-        rv_dual/= mesh.vert.area
-
-        av_dual = rv_dual + ff_dual
-        pv_dual = av_dual / hh_dual
-
-        rv_cell = trsk.cell_kite_sums * rv_dual
-        rv_cell/= mesh.cell.area
-
-        av_cell = rv_cell + ff_cell
-        pv_cell = av_cell / hh_cell
-
-        rv_edge = trsk.edge_vert_sums * rv_dual / 2.0
-        pv_edge = trsk.edge_vert_sums * pv_dual / 2.0
-        
-        rm_dual = trsk.dual_edge_sums * rv_edge / 3.0
-        
-        am_dual = rm_dual + ff_dual
-        pm_dual = am_dual / hh_dual
-
-        pv_edge, up_edge = upwinding(
-            mesh, trsk, cnfg, 
-            pv_dual, pm_dual, pv_cell, pv_edge, 
-            uu_edge, vv_edge, delta_t, up_bias)
-
-    ttoc = time.time()
-    tcpu.computePV = tcpu.computePV + (ttoc - ttic)
-
-    return rv_dual, pv_dual, rv_cell, pv_cell, \
-           pv_edge, up_edge
-
-
-def computeKE(mesh, trsk, cnfg, 
-              hh_cell, hh_edge, hh_dual, uu_edge, vv_edge,
-              delta_t, up_bias):
-
-    ttic = time.time()
-
-    if (cnfg.operators == "TRSK-CV"):
-
-        up_edge = np.zeros(mesh.edge.size, dtype=float)
-
-        if ("WEIGHT" in cnfg.ke_scheme):
-
-            hh_thin = 1.0E+02
-
-            ke_edge = 0.5 * (uu_edge ** 2 + 
-                             vv_edge ** 2 )
- 
-            hh_scal = hh_thin / hh_edge
-
-            ke_edge*= ((1.0 + hh_scal) ** 2) ** 2
-
-            ke_cell = trsk.cell_wing_sums * ke_edge
-            ke_cell/= mesh.cell.area
-
-            ke_dual = trsk.dual_stub_sums * ke_edge
-            ke_dual/= mesh.vert.area
-
-            hh_scal = hh_thin / hh_cell
-
-            ke_cell/= ((1.0 + hh_scal) ** 2) ** 2
-
-        else:  # CENTRE
-
-            ke_edge = 0.5 * (uu_edge ** 2 + 
-                             vv_edge ** 2 )
-
-            ke_dual = trsk.dual_stub_sums * ke_edge
-            ke_dual/= mesh.vert.area
-
-            ke_cell = trsk.cell_wing_sums * ke_edge
-            ke_cell/= mesh.cell.area
-
-    if (cnfg.operators == "TRSK-MD"):
-
-        up_edge = np.zeros(mesh.edge.size, dtype=float)
-
-        if ("WEIGHT" in cnfg.ke_scheme):
-
-            hh_thin = 1.0E+02
-
-            ke_edge = 0.25 * uu_edge ** 2 * \
-                  mesh.edge.clen * \
-                  mesh.edge.vlen
-
-            hh_scal = hh_thin / hh_edge
-
-            ke_edge*= ((1.0 + hh_scal) ** 2) ** 2
-
-            ke_cell = trsk.cell_edge_sums * ke_edge
-            ke_cell/= mesh.cell.area
-
-            ke_dual = trsk.dual_edge_sums * ke_edge
-            ke_dual/= mesh.vert.area
-
-            hh_scal = hh_thin / hh_cell
-
-            ke_cell/= ((1.0 + hh_scal) ** 2) ** 2
-
-        else:  # CENTRE
-
-            ke_edge = 0.25 * uu_edge ** 2 * \
-                  mesh.edge.clen * \
-                  mesh.edge.vlen
-
-            ke_dual = trsk.dual_edge_sums * ke_edge
-            ke_dual/= mesh.vert.area
-
-            ke_cell = trsk.cell_edge_sums * ke_edge
-            ke_cell/= mesh.cell.area
-
-    ttoc = time.time()
-    tcpu.computeKE = tcpu.computeKE + (ttoc - ttic)
-
-    return ke_dual, ke_cell, up_edge
-
-
-def advect_PV(mesh, trsk, cnfg, uh_edge, pv_edge):
-
-    ttic = time.time()
-
-    pv_flux = (
-        trsk.edge_flux_perp * (pv_edge * uh_edge) +
-        pv_edge * (trsk.edge_flux_perp * uh_edge)
-    )
-
-    ttoc = time.time()
-    tcpu.advect_PV = tcpu.advect_PV + (ttoc - ttic)
-
-    return pv_flux * -0.50
-
-
-def computeDU(mesh, trsk, cnfg, uu_edge):
-
-#-- Divergence(-only) dissipation
-
-    ttic = time.time()
-
-#-- div(u.n)
-    du_cell = trsk.cell_flux_sums * uu_edge
-    du_cell/= mesh.cell.area
-    
-    d2_cell = du_cell * cnfg.du_damp_2
-    d4_cell = du_cell * cnfg.du_damp_4  # NB. sqrt(vk)
-
-#-- D^2 = grad(vk * div(u.n))
-    d2_edge = trsk.edge_grad_norm * d2_cell
-    d4_edge = trsk.edge_grad_norm * d4_cell
-
-#-- div(D^2)
-    du_cell = trsk.cell_flux_sums * d4_edge
-    du_cell/= mesh.cell.area
-    
-    d4_cell = du_cell * cnfg.du_damp_4  # NB. sqrt(vk)
-
-#-- D^4 = grad(vk * div(D^2))
-    d4_edge = trsk.edge_grad_norm * d4_cell
-    
-    ttoc = time.time()
-    tcpu.computeDU = tcpu.computeDU + (ttoc - ttic)
-
-    return d2_edge - d4_edge
-    
-
 if (__name__ == "__main__"):
     parser = argparse.ArgumentParser(
         description=__doc__,
@@ -1428,7 +398,8 @@ if (__name__ == "__main__"):
         "--integrate", dest="integrate", type=str,
         default="RK22-FB",
         required=False, 
-        help="Time integration = {RK22-FB}, RK32-FB.")
+        help="Time integration = {RK22-FB}, RK32-FB."
+                               + "SP22, SP33, RK4.")
 
     parser.add_argument(
         "--up-scheme", dest="up_scheme", type=str,
@@ -1438,15 +409,15 @@ if (__name__ == "__main__"):
 
     parser.add_argument(
         "--pv-upwind", dest="pv_upwind", type=float,
-        default=1./80.,
+        default=1./30.,
         required=False,
-        help="Upwind PV.-flux bias {BIAS = +1./80.}.")
+        help="Upwind PV.-flux bias {BIAS = +1./40.}.")
     
     parser.add_argument(
         "--ke-upwind", dest="ke_upwind", type=float,
-        default=1./80.,
+        default=1./30.,
         required=False,
-        help="Upwind KE.-edge bias {BIAS = +1./80.}.")
+        help="Upwind KE.-edge bias {BIAS = +1./20.}.")
 
     parser.add_argument(
         "--pv-scheme", dest="pv_scheme", type=str,
@@ -1462,15 +433,15 @@ if (__name__ == "__main__"):
 
     parser.add_argument(
         "--du-damp-2", dest="du_damp_2", type=float,
-        default=0.E+00,
+        default=1.E+00,
         required=False,
-        help="DIV.(U) DEL^2 coeff. {DAMP = +0.E+00}.")
+        help="DIV.(U) DEL^2 coeff. {DAMP = +1.E+00}.")
 
     parser.add_argument(
         "--du-damp-4", dest="du_damp_4", type=float,
-        default=0.E+00,
+        default=1.E+00,
         required=False,
-        help="DIV.(U) DEL^4 coeff. {DAMP = +0.E+00}.")
+        help="DIV.(U) DEL^4 coeff. {DAMP = +1.E+00}.")
 
     parser.add_argument(
         "--operators", dest="operators", type=str,

--- a/wtc.py
+++ b/wtc.py
@@ -459,7 +459,7 @@ def wtc4(name, save, rsph, mesh, trsk):
 #-- solve -g * del^2 h = div f * u_perp for layer thickness,
 #-- leads to a h which is in discrete balance
 
-    print("Computing layer thickness...")
+    print("Computing flow thickness...")
 
     ff_vert = 2.0 * erot * np.sin(mesh.vert.ylat)
     ff_edge = trsk.edge_stub_sums * ff_vert

--- a/wtc.py
+++ b/wtc.py
@@ -21,13 +21,13 @@ def init(name, save, rsph, case):
 
 #------------------------------------ load an MPAS mesh file
 
-    print("Load the mesh file")
+    print("Loading the mesh file...")
 
     mesh = load_mesh(name, rsph)
     
 #------------------------------------ build TRSK matrix op's
 
-    print("Forming coefficients")
+    print("Forming coefficients...")
 
     trsk = trsk_mats(mesh)
 
@@ -356,7 +356,7 @@ def wtc4(name, save, rsph, mesh, trsk):
 
     sig0 = (2.0 * mesh.rsph / 1.0E+06) ** 2 
 
-    print("Integrate for speeds")
+    print("Computing streamfunction...")
 
     sf_vert = np.zeros(
         mesh.vert.size, dtype=np.float64)
@@ -399,7 +399,7 @@ def wtc4(name, save, rsph, mesh, trsk):
 
 
 
-    print("Calc. velocity field")
+    print("Computing velocity field...")
 
     uu_edge = trsk.edge_grad_perp * sf_vert * -1.
 
@@ -410,8 +410,6 @@ def wtc4(name, save, rsph, mesh, trsk):
 
     print("--> max(abs(unrm)):", np.max(uu_edge))
     print("--> sum(div(unrm)):", np.sum(du_cell))
-
-
 
     """
     ff_vert = 2.0 * erot * np.sin(mesh.vert.ylat)
@@ -458,11 +456,10 @@ def wtc4(name, save, rsph, mesh, trsk):
     hh_cell = cell_quad(mesh, fh_cell, fh_vert)
     """
 
-
 #-- solve -g * del^2 h = div f * u_perp for layer thickness,
 #-- leads to a h which is in discrete balance
 
-    print("Find layer thickness")
+    print("Computing layer thickness...")
 
     ff_vert = 2.0 * erot * np.sin(mesh.vert.ylat)
     ff_edge = trsk.edge_stub_sums * ff_vert


### PR DESCRIPTION
- Add Anticipated UpSTream (AUST) formulation for upwind PV fluxes (APVM + LUST type method).
- Add RCM-type mesh reordering for cache-locality.
- Split-up time integration and spatial discretisation routines.