### PR TITLE
Add command-line switch for setting FBFCs in RK32

### DIFF
--- a/_dt.py
+++ b/_dt.py
@@ -109,7 +109,7 @@ def step_RK32(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
 
     ttic = time.time()
 
-    BETA = cnfg.betas[0] * ("FB" in cnfg.integrate)
+    BETA = cnfg.fb_weight[0] * ("FB" in cnfg.integrate)
 
     rh_cell = rhs_all_h(
         mesh, trsk, flow, cnfg, hh_cell, uu_edge)
@@ -143,7 +143,7 @@ def step_RK32(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
 
     ttic = time.time()
 
-    BETA = cnfg.betas[1] * ("FB" in cnfg.integrate)
+    BETA = cnfg.fb_weight[1] * ("FB" in cnfg.integrate)
    
     rh_cell = rhs_all_h(
         mesh, trsk, flow, cnfg, h1_cell, u1_edge)
@@ -178,7 +178,7 @@ def step_RK32(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
 
     ttic = time.time()
 
-    BETA = cnfg.betas[2] * ("FB" in cnfg.integrate)
+    BETA = cnfg.fb_weight[2] * ("FB" in cnfg.integrate)
 
     rh_cell = rhs_all_h(
         mesh, trsk, flow, cnfg, h2_cell, u2_edge)

--- a/_dt.py
+++ b/_dt.py
@@ -116,7 +116,6 @@ def step_RK32(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
     ttic = time.time()
     
     if cnfg.fb_weight:
-        print('no def')
         BETA = cnfg.fb_weight[0] * ("FB" in cnfg.integrate)
     else:
         BETA = (1.0 / 3.0) * ("FB" in cnfg.integrate)

--- a/_dt.py
+++ b/_dt.py
@@ -96,7 +96,7 @@ def step_RK22(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
            rv_dual, pv_dual, ke_bias, pv_bias
 
 
-def step_RK32(mesh, trsk, flow, cnfg, hh_cell, uu_edge, betas):
+def step_RK32(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
 
 #-- A 3-stage RK2 + FB scheme, a'la MPAS-A:
 #-- L.J. Wicker, W.C. Skamarock (2002): Time-Splitting Methods for 
@@ -109,7 +109,7 @@ def step_RK32(mesh, trsk, flow, cnfg, hh_cell, uu_edge, betas):
 
     ttic = time.time()
 
-    BETA = betas[0] * ("FB" in cnfg.integrate)
+    BETA = cnfg.betas[0] * ("FB" in cnfg.integrate)
 
     rh_cell = rhs_all_h(
         mesh, trsk, flow, cnfg, hh_cell, uu_edge)
@@ -143,7 +143,7 @@ def step_RK32(mesh, trsk, flow, cnfg, hh_cell, uu_edge, betas):
 
     ttic = time.time()
 
-    BETA = betas[1] * ("FB" in cnfg.integrate)
+    BETA = cnfg.betas[1] * ("FB" in cnfg.integrate)
    
     rh_cell = rhs_all_h(
         mesh, trsk, flow, cnfg, h1_cell, u1_edge)
@@ -178,7 +178,7 @@ def step_RK32(mesh, trsk, flow, cnfg, hh_cell, uu_edge, betas):
 
     ttic = time.time()
 
-    BETA = betas[2] * ("FB" in cnfg.integrate)
+    BETA = cnfg.betas[2] * ("FB" in cnfg.integrate)
 
     rh_cell = rhs_all_h(
         mesh, trsk, flow, cnfg, h2_cell, u2_edge)

--- a/_dt.py
+++ b/_dt.py
@@ -23,7 +23,10 @@ def step_RK22(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
 
     ttic = time.time()
 
-    BETA = (1.0 / 3.0) * ("FB" in cnfg.integrate)
+    if cnfg.fb_weight:
+        BETA = cnfg.fb_weight[0] * ("FB" in cnfg.integrate)
+    else:
+        BETA = (1.0 / 3.0) * ("FB" in cnfg.integrate)
 
     rh_cell = rhs_all_h(
         mesh, trsk, flow, cnfg, hh_cell, uu_edge)
@@ -57,7 +60,10 @@ def step_RK22(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
 
     ttic = time.time()
 
-    BETA = (2.0 / 3.0) * ("FB" in cnfg.integrate)
+    if cnfg.fb_weight:
+        BETA = cnfg.fb_weight[1] * ("FB" in cnfg.integrate)
+    else:
+        BETA = (2.0 / 3.0) * ("FB" in cnfg.integrate)
 
     hm_cell = 0.5 * hh_cell + 0.5 * h1_cell
     um_edge = 0.5 * uu_edge + 0.5 * u1_edge
@@ -108,8 +114,13 @@ def step_RK32(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
 #-- 1st RK + FB stage
 
     ttic = time.time()
+    
+    if cnfg.fb_weight:
+        print('no def')
+        BETA = cnfg.fb_weight[0] * ("FB" in cnfg.integrate)
+    else:
+        BETA = (1.0 / 3.0) * ("FB" in cnfg.integrate)
 
-    BETA = cnfg.fb_weight[0] * ("FB" in cnfg.integrate)
 
     rh_cell = rhs_all_h(
         mesh, trsk, flow, cnfg, hh_cell, uu_edge)
@@ -143,7 +154,10 @@ def step_RK32(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
 
     ttic = time.time()
 
-    BETA = cnfg.fb_weight[1] * ("FB" in cnfg.integrate)
+    if cnfg.fb_weight:
+        BETA = cnfg.fb_weight[1] * ("FB" in cnfg.integrate)
+    else:
+        BETA = (1.0 / 2.0) * ("FB" in cnfg.integrate)
    
     rh_cell = rhs_all_h(
         mesh, trsk, flow, cnfg, h1_cell, u1_edge)
@@ -178,7 +192,10 @@ def step_RK32(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
 
     ttic = time.time()
 
-    BETA = cnfg.fb_weight[2] * ("FB" in cnfg.integrate)
+    if cnfg.fb_weight:
+        BETA = cnfg.fb_weight[2] * ("FB" in cnfg.integrate)
+    else:
+        BETA = (89.0 / 300.0) * ("FB" in cnfg.integrate)
 
     rh_cell = rhs_all_h(
         mesh, trsk, flow, cnfg, h2_cell, u2_edge)

--- a/_dt.py
+++ b/_dt.py
@@ -96,7 +96,7 @@ def step_RK22(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
            rv_dual, pv_dual, ke_bias, pv_bias
 
 
-def step_RK32(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
+def step_RK32(mesh, trsk, flow, cnfg, hh_cell, uu_edge, betas):
 
 #-- A 3-stage RK2 + FB scheme, a'la MPAS-A:
 #-- L.J. Wicker, W.C. Skamarock (2002): Time-Splitting Methods for 
@@ -109,8 +109,7 @@ def step_RK32(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
 
     ttic = time.time()
 
-   #BETA = (1.0 / 3.0) * ("FB" in cnfg.integrate)
-    BETA = (2.0 / 5.0) * ("FB" in cnfg.integrate)
+    BETA = betas[0] * ("FB" in cnfg.integrate)
 
     rh_cell = rhs_all_h(
         mesh, trsk, flow, cnfg, hh_cell, uu_edge)
@@ -144,8 +143,7 @@ def step_RK32(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
 
     ttic = time.time()
 
-   #BETA = (1.0 / 2.0) * ("FB" in cnfg.integrate)
-    BETA = (13. / 30.) * ("FB" in cnfg.integrate)
+    BETA = betas[1] * ("FB" in cnfg.integrate)
    
     rh_cell = rhs_all_h(
         mesh, trsk, flow, cnfg, h1_cell, u1_edge)
@@ -180,9 +178,7 @@ def step_RK32(mesh, trsk, flow, cnfg, hh_cell, uu_edge):
 
     ttic = time.time()
 
-   #BETA = ( 89./ 300) * ("FB" in cnfg.integrate)
-   #BETA = ( 7.0/ 24.) * ("FB" in cnfg.integrate)
-    BETA = ( 29./ 80.) * ("FB" in cnfg.integrate)
+    BETA = betas[2] * ("FB" in cnfg.integrate)
 
     rh_cell = rhs_all_h(
         mesh, trsk, flow, cnfg, h2_cell, u2_edge)

--- a/swe.py
+++ b/swe.py
@@ -107,7 +107,8 @@ def swe(cnfg):
             rv_cell, pv_cell, \
             rv_dual, pv_dual, \
             ke_bias, pv_bias = step_RK32(
-                mesh, trsk, flow, cnfg, hh_cell, uu_edge)
+                mesh, trsk, flow, cnfg, hh_cell, uu_edge,
+                cnfg.betas)
 
         if ("SP33" in cnfg.integrate):
 
@@ -535,6 +536,14 @@ if (__name__ == "__main__"):
         type=lambda x: bool(strtobool(str(x.strip()))),
         required=False, 
         default=False, help="Disable coriolis terms.")
+
+    parser.add_argument(
+        "--betas", dest="betas", type=float,
+        required=False,
+        nargs=3,
+        default=[1.0/3.0, 1.0/2.0, 89.0/300.0],
+        help="FBFCs for RK32")
+
 
     swe(parser.parse_args())
 

--- a/swe.py
+++ b/swe.py
@@ -537,11 +537,11 @@ if (__name__ == "__main__"):
         default=False, help="Disable coriolis terms.")
 
     parser.add_argument(
-        "--betas", dest="betas", type=float,
+        "--FB-weight", dest="fb_weight", type=float,
         required=False,
         nargs=3,
         default=[1.0/3.0, 1.0/2.0, 89.0/300.0],
-        help="FBFCs for RK32")
+        help="FB weights for RK32.")
 
 
     swe(parser.parse_args())

--- a/swe.py
+++ b/swe.py
@@ -539,8 +539,7 @@ if (__name__ == "__main__"):
     parser.add_argument(
         "--FB-weight", dest="fb_weight", type=float,
         required=False,
-        nargs=3,
-        default=[1.0/3.0, 1.0/2.0, 89.0/300.0],
+        nargs='*',
         help="FB weights for RK32.")
 
 

--- a/swe.py
+++ b/swe.py
@@ -107,8 +107,7 @@ def swe(cnfg):
             rv_cell, pv_cell, \
             rv_dual, pv_dual, \
             ke_bias, pv_bias = step_RK32(
-                mesh, trsk, flow, cnfg, hh_cell, uu_edge,
-                cnfg.betas)
+                mesh, trsk, flow, cnfg, hh_cell, uu_edge)
 
         if ("SP33" in cnfg.integrate):
 

--- a/swe.py
+++ b/swe.py
@@ -549,7 +549,7 @@ if (__name__ == "__main__"):
         "--FB-weight", dest="fb_weight", type=float,
         required=False,
         nargs='*',
-        help="FB weights for RK32.")
+        help="Forward-backward weights for integrators.")
 
 
     swe(parser.parse_args())

--- a/swe.py
+++ b/swe.py
@@ -51,6 +51,15 @@ def swe(cnfg):
     path, file = os.path.split(name)
     save = os.path.join(path, "out_" + file)
 
+    if cnfg.fb_weight:
+        nweights = len(cnfg.fb_weight)
+        if ("RK22" in cnfg.integrate) and (nweights != 2):
+            raise Exception("RK22 requires 2 FB-weights, " +
+                            "{} provided".format(nweights))
+        elif ("RK32" in cnfg.integrate) and (nweights != 3):
+            raise Exception("RK32 requires 3 FB-weights, " +
+                            "{} provided".format(nweights))
+
     print("Loading input assets...")
     
     # load mesh + init. conditions


### PR DESCRIPTION
@dengwirda, this adds an optional command line switch that sets the value for `[beta1, beta2, beta3]` in RK32-FB for quick testing. 

Ex:
```
python3 swe.py ... --integrate RK32-FB --betas 0.5 0.5 0.33
```

The default value is `1./3 1./2 89./300`.